### PR TITLE
DocEngineer: Phase 3.1.1 - New Landing Page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,10 +13,10 @@ export default function Home() {
             Build scalable workflows in minutes — no heavy coding required.
           </p>
           <div className="hero-buttons">
-            <Link className="button button--primary button--lg" to="/docs/01-quickstart/quickstart-overview">
+            <Link className="button button--primary button--lg" to="/docs/quickstart/quickstart-overview">
               Quickstart
             </Link>
-            <Link className="button button--secondary button--lg" to="/docs/02-concept/concept">
+            <Link className="button button--secondary button--lg" to="/docs/concept">
               Concepts
             </Link>
           </div>
@@ -32,7 +32,7 @@ export default function Home() {
           </div>
           <div className="feature-card">
             <h3>Low-Code</h3>
-            <p>Build workflows via UI or JavaScript/Python — no heavy coding required.</p>
+            <p>Build workflows via UI and JavaScript/Python — no heavy coding required.</p>
           </div>
           <div className="feature-card">
             <h3>Connected</h3>
@@ -44,19 +44,19 @@ export default function Home() {
       <section className="quick-nav">
         <h2>Choose Your Path</h2>
         <div className="nav-grid">
-          <Link to="/docs/01-quickstart/quickstart-overview" className="nav-tile">
+          <Link to="/docs/quickstart/quickstart-overview" className="nav-tile">
             <h3>🚀 New to layline.io?</h3>
             <p>Start here: Install and run your first pipeline in minutes.</p>
           </Link>
-          <Link to="/docs/01-quickstart/02-install-local" className="nav-tile">
+          <Link to="/docs/quickstart/install-local" className="nav-tile">
             <h3>💻 Local Installation</h3>
             <p>Install layline.io on your local machine.</p>
           </Link>
-          <Link to="/docs/01-quickstart/03-install-docker" className="nav-tile">
+          <Link to="/docs/quickstart/install-docker" className="nav-tile">
             <h3>🐳 Docker Deployment</h3>
             <p>Run layline.io using Docker.</p>
           </Link>
-          <Link to="/docs/02-concept/concept" className="nav-tile">
+          <Link to="/docs/concept" className="nav-tile">
             <h3>📚 Core Concepts</h3>
             <p>Learn about workflows, clusters, and assets.</p>
           </Link>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,20 +7,22 @@ export default function Home() {
     <Layout title="layline.io Documentation" description="Master event data processing with layline.io">
       <header className="hero-section">
         <div className="hero-content">
-          <h1>Master Event Data Processing with layline.io</h1>
+          <h1>Get Started with layline.io</h1>
           <p>
-            Explore the documentation for a low-code platform that powers real-time and batch event processing.
+            A low-code platform for real-time and batch event data processing.
+            Build scalable workflows in minutes — no heavy coding required.
           </p>
           <div className="hero-buttons">
-            <Link className="button button--primary button--lg" to="/docs/quickstart/quickstart-overview">
-              Get Started
+            <Link className="button button--primary button--lg" to="/docs/01-quickstart/quickstart-overview">
+              Quickstart
             </Link>
-            <Link className="button button--secondary button--lg" to="/docs/concept">
-              Learn the Concepts
+            <Link className="button button--secondary button--lg" to="/docs/02-concept/concept">
+              Concepts
             </Link>
           </div>
         </div>
       </header>
+
       <section className="value-prop">
         <h2>Why layline.io?</h2>
         <div className="features-grid">
@@ -29,8 +31,8 @@ export default function Home() {
             <p>Handle massive event data with real-time speed and elastic scalability.</p>
           </div>
           <div className="feature-card">
-            <h3>Configurable</h3>
-            <p>Build workflows via UI or Javascript or Python — no heavy coding required.</p>
+            <h3>Low-Code</h3>
+            <p>Build workflows via UI or JavaScript/Python — no heavy coding required.</p>
           </div>
           <div className="feature-card">
             <h3>Connected</h3>
@@ -38,34 +40,36 @@ export default function Home() {
           </div>
         </div>
       </section>
+
       <section className="quick-nav">
-        <h2>Where to Begin?</h2>
+        <h2>Choose Your Path</h2>
         <div className="nav-grid">
-          <Link to="/docs/quickstart/quickstart-overview" className="nav-tile">
-            <h3>Quickstart</h3>
-            <p>Set up in minutes.</p>
+          <Link to="/docs/01-quickstart/quickstart-overview" className="nav-tile">
+            <h3>🚀 New to layline.io?</h3>
+            <p>Start here: Install and run your first pipeline in minutes.</p>
           </Link>
-          <Link to="/docs/concept" className="nav-tile">
-            <h3>Concepts</h3>
-            <p>Grasp workflows and clusters.</p>
+          <Link to="/docs/01-quickstart/02-install-local" className="nav-tile">
+            <h3>💻 Local Installation</h3>
+            <p>Install layline.io on your local machine.</p>
           </Link>
-          <Link to="/docs/assets" className="nav-tile">
-            <h3>Assets</h3>
-            <p>Configure sources and sinks.</p>
+          <Link to="/docs/01-quickstart/03-install-docker" className="nav-tile">
+            <h3>🐳 Docker Deployment</h3>
+            <p>Run layline.io using Docker.</p>
           </Link>
-          <Link to="mailto:support@layline.io" className="nav-tile">
-            <h3>Support</h3>
-            <p>Need help? Contact us!</p>
+          <Link to="/docs/02-concept/concept" className="nav-tile">
+            <h3>📚 Core Concepts</h3>
+            <p>Learn about workflows, clusters, and assets.</p>
           </Link>
         </div>
       </section>
+
       <section className="testimonial">
         <h2>Real-World Impact</h2>
         <blockquote>
           <p>
             "layline.io replaced our legacy system with a scalable, cloud-native solution, slashing resources by 75%."
           </p>
-          <footer>— freenet, Europe’s largest MVNO</footer>
+          <footer>— freenet, Europe's largest MVNO</footer>
         </blockquote>
         <Link className="button button--outline" to="https://layline.io">
           See How It Works


### PR DESCRIPTION
## Summary

Created a new landing page with 'Get Started' focus as part of Phase 3.1.1.

### Changes

- **Hero section**: Updated to lead with 'Get Started with layline.io' messaging
- **Installation paths**: Added clear options for Local vs Docker installation
- **Navigation**: Changed from generic sections to 'Choose Your Path' with specific install options
- **Quickstart**: Links preserved to  folder structure

### Files Changed

-  - Landing page redesign

### Preview

Landing page now provides clear on-ramps:
1. New users → Quickstart overview
2. Local install → 02-install-local  
3. Docker → 03-install-docker
4. Concepts → 02-concept

---