### PR TITLE
Docs: Cherry-pick Google Cloud Connection and GCS Sink to main

### DIFF
--- a/docs/03-assets/connections/asset-connection-google-cloud.md
+++ b/docs/03-assets/connections/asset-connection-google-cloud.md
@@ -14,78 +14,53 @@ import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 
 ## Purpose
 
-Provides OAuth-based authentication for Google Cloud services. This connection is used by Google Cloud Storage (GCS) Sink and GCS Source to authenticate against Google Cloud Storage using the OAuth 2.0 protocol.
-
-## Prerequisites
-
-- A Google Cloud project with the Google Cloud Storage API enabled.
-- An **OAuth Client** resource asset configured in layline.io (or use the default layline.io shared client). See [Resources](#resources) below.
+Provides OAuth-based authentication for Google Cloud services. This connection is used by GCS Sink and GCS Source to authenticate against Google Cloud Storage.
 
 ## Configuration
 
 ### Name & Description
 
-![Name & Description (Connection Google Cloud)](.asset-connection-google-cloud_images/asset-connection-google-cloud-name-description.png "Name & Description (Connection Google Cloud)")
+**`Name`** — Unique name for this asset within the project.
 
-**Name** — Unique name for this asset within the project. Spaces are not allowed.
+**`Description`** — Optional description of what this connection is used for.
 
-**Description** — Optional description of what this connection is used for.
-
-The **Asset Usage** box shows how many times this Asset is used and which parts are referencing it.
+The **`Asset Usage`** box shows how many times this Asset is used and which parts are referencing it.
 
 ### Required Roles
 
-![Required Roles (Connection Google Cloud)](.asset-connection-google-cloud_images/asset-connection-google-cloud-required-roles.png "Required Roles (Connection Google Cloud)")
-
 In case you are deploying to a Cluster with Reactive Engine Nodes that have specific Roles configured, you can restrict use of this Asset to Nodes with matching roles. Leave empty to match all Nodes.
-
-### Resources
-
-![Resources (Connection Google Cloud)](.asset-connection-google-cloud_images/asset-connection-google-cloud-resources.png "Resources (Connection Google Cloud)")
-
-Link an **OAuth Client** resource to this connection. Only assets of type `oAuthClient` are available in the dropdown.
-
-If no OAuth Client resource exists in the project, you must create one first. The OAuth Client resource defines the client credentials (client ID, scopes) that layline.io will use when requesting an access token from Google's OAuth server.
 
 ### Google Cloud Settings
 
-![Google Cloud Settings (Connection Google Cloud)](.asset-connection-google-cloud_images/asset-connection-google-cloud-settings.png "Google Cloud Settings (Connection Google Cloud)")
+#### Credential Type
 
-**Credential Type** — The OAuth 2.0 authentication flow to use.
+Select the OAuth flow to use:
 
-| Option | Behavior |
-|--------|----------|
-| OAuth Client Credentials | Service-account style authentication. Exchange a client ID and secret for an access token. Suitable for server-to-server communication. |
-| OAuth Device Code | User-identity authentication via the device code flow. The user approves access on a separate device. Suitable for CLI tools and scenarios where a browser is available. |
+| Option | Description |
+|--------|-------------|
+| **OAuth Client Credentials** | Service-account style authentication using a client ID and secret. |
+| **OAuth Device Code** | User-identity authentication via device code flow. |
 
-**Authority** — The OAuth 2.0 authority URL. This is the endpoint that issues access tokens. Defaults to `https://accounts.google.com`. In most cases, this default does not need to be changed.
+#### Authority
 
-**Client ID** — The OAuth client ID issued by Google. Defaults to layline.io's shared client ID:
+The OAuth authority URL. Defaults to `https://accounts.google.com`. In most cases, this does not need to be changed.
 
-```
-407603625325-45ik7ma1elfme3qidga7jstkbfnfmhdu.apps.googleusercontent.com
-```
+#### Client ID
 
-To use your own OAuth client (recommended for production), replace this with your client's client ID. You can also use a placeholder referencing an [Environment Resource](../resources/asset-resource-environment):
+The Google OAuth client ID. Defaults to layline.io's shared client ID. You can replace this with your own OAuth client ID if needed.
 
-```
-${GOOGLE_CLIENT_ID}
-```
+#### Scopes
 
-**Scopes** — Add the OAuth scopes required for your use case. Each scope is entered as a chip — type the scope value and press Enter** to add it.
+Add the OAuth scopes required for your use case. Each scope is entered as a chip — type the scope value and press **Enter** to add it.
 
 Default scopes:
 
-- `offline_access` — allows refreshing access tokens without re-prompting the user
-- `user.read` — grants read access to user profile information
-
-Add any additional scopes required by your Google Cloud project (for example, `https://www.googleapis.com/auth/devstorage.read_write` for GCS read/write access).
+- `offline_access`
+- `user.read`
 
 ## Behavior
 
-The connection configuration is validated when you save the asset. The actual reachability of Google Cloud services is confirmed at workflow runtime when the Reactive Engine attempts to use this connection.
-
-All Google Cloud Settings fields can be overridden in child assets or inherited from a parent asset in a hierarchy.
+The connection is validated at configuration time. The actual reachability of Google Cloud services is also confirmed at workflow runtime when the Reactive Engine attempts to use this connection.
 
 ## See Also
 

--- a/docs/03-assets/connections/asset-connection-google-cloud.md
+++ b/docs/03-assets/connections/asset-connection-google-cloud.md
@@ -14,13 +14,20 @@ import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 
 ## Purpose
 
-Provides OAuth-based authentication for Google Cloud services. This connection is used by GCS Sink and GCS Source to authenticate against Google Cloud Storage.
+Provides OAuth-based authentication for Google Cloud services. This connection is used by Google Cloud Storage (GCS) Sink and GCS Source to authenticate against Google Cloud Storage using the OAuth 2.0 protocol.
+
+## Prerequisites
+
+- A Google Cloud project with the Google Cloud Storage API enabled.
+- An **OAuth Client** resource asset configured in layline.io (or use the default layline.io shared client). See [Resources](#resources) below.
 
 ## Configuration
 
 ### Name & Description
 
-**`Name`** — Unique name for this asset within the project.
+![Name & Description (Connection Google Cloud)](.asset-connection-google-cloud_images/asset-connection-google-cloud-name-description.png "Name & Description (Connection Google Cloud)")
+
+**`Name`** — Unique name for this asset within the project. Spaces are not allowed.
 
 **`Description`** — Optional description of what this connection is used for.
 
@@ -28,39 +35,65 @@ The **`Asset Usage`** box shows how many times this Asset is used and which part
 
 ### Required Roles
 
+![Required Roles (Connection Google Cloud)](.asset-connection-google-cloud_images/asset-connection-google-cloud-required-roles.png "Required Roles (Connection Google Cloud)")
+
 In case you are deploying to a Cluster with Reactive Engine Nodes that have specific Roles configured, you can restrict use of this Asset to Nodes with matching roles. Leave empty to match all Nodes.
+
+### Resources
+
+![Resources (Connection Google Cloud)](.asset-connection-google-cloud_images/asset-connection-google-cloud-resources.png "Resources (Connection Google Cloud)")
+
+Link an **OAuth Client** resource to this connection. Only assets of type `oAuthClient` are available in the dropdown.
+
+If no OAuth Client resource exists in the project, you must create one first. The OAuth Client resource defines the client credentials (client ID, scopes) that layline.io will use when requesting an access token from Google's OAuth server.
 
 ### Google Cloud Settings
 
+![Google Cloud Settings (Connection Google Cloud)](.asset-connection-google-cloud_images/asset-connection-google-cloud-settings.png "Google Cloud Settings (Connection Google Cloud)")
+
 #### Credential Type
 
-Select the OAuth flow to use:
+Select the OAuth 2.0 authentication flow to use:
 
-| Option | Description |
-|--------|-------------|
-| **OAuth Client Credentials** | Service-account style authentication using a client ID and secret. |
-| **OAuth Device Code** | User-identity authentication via device code flow. |
+| Credential Type | Description |
+|-----------------|-------------|
+| **OAuth Client Credentials** | Service-account style authentication. Exchange a client ID and secret for an access token. Suitable for server-to-server communication. |
+| **OAuth Device Code** | User-identity authentication via the device code flow. The user approves access on a separate device. Suitable for CLI tools and scenarios where a browser is available. |
 
-#### Authority
+#### Authority *(inheritable)*
 
-The OAuth authority URL. Defaults to `https://accounts.google.com`. In most cases, this does not need to be changed.
+The OAuth 2.0 authority URL. This is the endpoint that issues access tokens. Defaults to `https://accounts.google.com`. In most cases, this default does not need to be changed.
 
-#### Client ID
+#### Client ID *(inheritable)*
 
-The Google OAuth client ID. Defaults to layline.io's shared client ID. You can replace this with your own OAuth client ID if needed.
+The OAuth client ID issued by Google. Defaults to layline.io's shared client ID:
 
-#### Scopes
+```
+407603625325-45ik7ma1elfme3qidga7jstkbfnfmhdu.apps.googleusercontent.com
+```
+
+To use your own OAuth client (recommended for production), replace this with your client's client ID. You can also use a placeholder referencing an [Environment Resource](../resources/asset-resource-environment):
+
+```
+${GOOGLE_CLIENT_ID}
+```
+
+#### Scopes *(inheritable)*
 
 Add the OAuth scopes required for your use case. Each scope is entered as a chip — type the scope value and press **Enter** to add it.
 
 Default scopes:
 
-- `offline_access`
-- `user.read`
+- `offline_access` — allows refreshing access tokens without re-prompting the user
+- `user.read` — grants read access to user profile information
+
+Add any additional scopes required by your Google Cloud project (for example, `https://www.googleapis.com/auth/devstorage.read_write` for GCS read/write access).
 
 ## Behavior
 
-The connection is validated at configuration time. The actual reachability of Google Cloud services is also confirmed at workflow runtime when the Reactive Engine attempts to use this connection.
+The connection configuration is validated when you save the asset. The actual reachability of Google Cloud services is confirmed at workflow runtime when the Reactive Engine attempts to use this connection.
+
+All Google Cloud Settings fields marked *(inheritable)* can be overridden in child assets or inherited from a parent asset in a hierarchy.
 
 ## See Also
 

--- a/docs/03-assets/connections/asset-connection-google-cloud.md
+++ b/docs/03-assets/connections/asset-connection-google-cloud.md
@@ -27,11 +27,11 @@ Provides OAuth-based authentication for Google Cloud services. This connection i
 
 ![Name & Description (Connection Google Cloud)](.asset-connection-google-cloud_images/asset-connection-google-cloud-name-description.png "Name & Description (Connection Google Cloud)")
 
-**`Name`** — Unique name for this asset within the project. Spaces are not allowed.
+**Name** — Unique name for this asset within the project. Spaces are not allowed.
 
-**`Description`** — Optional description of what this connection is used for.
+**Description** — Optional description of what this connection is used for.
 
-The **`Asset Usage`** box shows how many times this Asset is used and which parts are referencing it.
+The **Asset Usage** box shows how many times this Asset is used and which parts are referencing it.
 
 ### Required Roles
 

--- a/docs/03-assets/connections/asset-connection-google-cloud.md
+++ b/docs/03-assets/connections/asset-connection-google-cloud.md
@@ -58,9 +58,9 @@ If no OAuth Client resource exists in the project, you must create one first. Th
 | OAuth Client Credentials | Service-account style authentication. Exchange a client ID and secret for an access token. Suitable for server-to-server communication. |
 | OAuth Device Code | User-identity authentication via the device code flow. The user approves access on a separate device. Suitable for CLI tools and scenarios where a browser is available. |
 
-**Authority *(inheritable)* — The OAuth 2.0 authority URL. This is the endpoint that issues access tokens. Defaults to `https://accounts.google.com`. In most cases, this default does not need to be changed.
+**Authority** — The OAuth 2.0 authority URL. This is the endpoint that issues access tokens. Defaults to `https://accounts.google.com`. In most cases, this default does not need to be changed.
 
-**Client ID *(inheritable)* — The OAuth client ID issued by Google. Defaults to layline.io's shared client ID:
+**Client ID** — The OAuth client ID issued by Google. Defaults to layline.io's shared client ID:
 
 ```
 407603625325-45ik7ma1elfme3qidga7jstkbfnfmhdu.apps.googleusercontent.com
@@ -72,7 +72,7 @@ To use your own OAuth client (recommended for production), replace this with you
 ${GOOGLE_CLIENT_ID}
 ```
 
-**Scopes *(inheritable)* — Add the OAuth scopes required for your use case. Each scope is entered as a chip — type the scope value and press **Enter** to add it.
+**Scopes** — Add the OAuth scopes required for your use case. Each scope is entered as a chip — type the scope value and press Enter** to add it.
 
 Default scopes:
 
@@ -85,7 +85,7 @@ Add any additional scopes required by your Google Cloud project (for example, `h
 
 The connection configuration is validated when you save the asset. The actual reachability of Google Cloud services is confirmed at workflow runtime when the Reactive Engine attempts to use this connection.
 
-All Google Cloud Settings fields marked *(inheritable)* can be overridden in child assets or inherited from a parent asset in a hierarchy.
+All Google Cloud Settings fields can be overridden in child assets or inherited from a parent asset in a hierarchy.
 
 ## See Also
 

--- a/docs/03-assets/connections/asset-connection-google-cloud.md
+++ b/docs/03-assets/connections/asset-connection-google-cloud.md
@@ -51,22 +51,16 @@ If no OAuth Client resource exists in the project, you must create one first. Th
 
 ![Google Cloud Settings (Connection Google Cloud)](.asset-connection-google-cloud_images/asset-connection-google-cloud-settings.png "Google Cloud Settings (Connection Google Cloud)")
 
-#### Credential Type
+**Credential Type** — The OAuth 2.0 authentication flow to use.
 
-Select the OAuth 2.0 authentication flow to use:
+| Option | Behavior |
+|--------|----------|
+| OAuth Client Credentials | Service-account style authentication. Exchange a client ID and secret for an access token. Suitable for server-to-server communication. |
+| OAuth Device Code | User-identity authentication via the device code flow. The user approves access on a separate device. Suitable for CLI tools and scenarios where a browser is available. |
 
-| Credential Type | Description |
-|-----------------|-------------|
-| **OAuth Client Credentials** | Service-account style authentication. Exchange a client ID and secret for an access token. Suitable for server-to-server communication. |
-| **OAuth Device Code** | User-identity authentication via the device code flow. The user approves access on a separate device. Suitable for CLI tools and scenarios where a browser is available. |
+**Authority *(inheritable)* — The OAuth 2.0 authority URL. This is the endpoint that issues access tokens. Defaults to `https://accounts.google.com`. In most cases, this default does not need to be changed.
 
-#### Authority *(inheritable)*
-
-The OAuth 2.0 authority URL. This is the endpoint that issues access tokens. Defaults to `https://accounts.google.com`. In most cases, this default does not need to be changed.
-
-#### Client ID *(inheritable)*
-
-The OAuth client ID issued by Google. Defaults to layline.io's shared client ID:
+**Client ID *(inheritable)* — The OAuth client ID issued by Google. Defaults to layline.io's shared client ID:
 
 ```
 407603625325-45ik7ma1elfme3qidga7jstkbfnfmhdu.apps.googleusercontent.com
@@ -78,9 +72,7 @@ To use your own OAuth client (recommended for production), replace this with you
 ${GOOGLE_CLIENT_ID}
 ```
 
-#### Scopes *(inheritable)*
-
-Add the OAuth scopes required for your use case. Each scope is entered as a chip — type the scope value and press **Enter** to add it.
+**Scopes *(inheritable)* — Add the OAuth scopes required for your use case. Each scope is entered as a chip — type the scope value and press **Enter** to add it.
 
 Default scopes:
 

--- a/docs/03-assets/sinks/asset-sink-gcs.md
+++ b/docs/03-assets/sinks/asset-sink-gcs.md
@@ -14,89 +14,110 @@ import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 
 ## Purpose
 
-Writes messages to a Google Cloud Storage (GCS) bucket as objects. Each incoming message produces one object in the configured bucket, under the configured prefix path.
+Writes messages to a Google Cloud Storage (GCS) bucket as objects. Each incoming message produces one object in the configured bucket, under the configured prefix path. Authentication is handled via a linked Google Cloud Connection asset using OAuth 2.0.
 
 ## Prerequisites
 
 - A [**Google Cloud Connection**](../connections/asset-connection-google-cloud) asset configured with the appropriate OAuth scopes.
-- A project open in layline.io with the connection created above.
+- A Google Cloud project with the Google Cloud Storage API enabled.
+- A GCS bucket in that project.
 
 ## Configuration
 
 ### Name & Description
 
-**`Name`** — Unique name for this asset within the project.
+![Name & Description (Sink GCS)](.asset-sink-gcs_images/asset-sink-gcs-name-description.png "Name & Description (Sink GCS)")
 
-**`Description`** — Optional description.
+**`Name`** — Unique name for this asset within the project. Spaces are not allowed.
+
+**`Description`** — Optional description of what this sink is used for.
 
 The **`Asset Usage`** box shows how many times this Asset is used and which parts are referencing it.
 
 ### Required Roles
 
+![Required Roles (Sink GCS)](.asset-sink-gcs_images/asset-sink-gcs-required-roles.png "Required Roles (Sink GCS)")
+
 In case you are deploying to a Cluster with Reactive Engine Nodes that have specific Roles configured, you can restrict use of this Asset to Nodes with matching roles. Leave empty to match all Nodes.
 
 ### Google Cloud Storage Settings
 
+![Google Cloud Storage Settings (Sink GCS)](.asset-sink-gcs_images/asset-sink-gcs-settings.png "Google Cloud Storage Settings (Sink GCS)")
+
 #### Connection
 
-Select a [**Google Cloud Connection**](../connections/asset-connection-google-cloud) from the list. The connection must exist before you can configure the remaining fields.
+Select a [**Google Cloud Connection**](../connections/asset-connection-google-cloud) from the list. This field is required — the remaining fields cannot be configured until a connection is selected.
 
-#### Project ID
+#### Project ID *(inheritable)*
 
 The Google Cloud project ID that owns the target bucket.
 
-#### Bucket Name
+#### Bucket Name *(inheritable)*
 
-The name of the GCS bucket to write to. Enter the bucket name as plain text.
+The name of the GCS bucket to write to. Enter the bucket name as plain text. The sink does not validate bucket existence at configuration time — this is checked at workflow runtime.
 
-#### Folder Prefix
+#### Folder Prefix *(inheritable)*
 
-A path prefix within the bucket under which objects will be written. For example, `logs/` or `data/output/`. Enter as plain text.
+A path prefix within the bucket under which objects will be written. For example: `logs/` or `data/output/`. Enter as plain text.
 
-#### Object Prefix
+Note that GCS has a flat namespace — there are no real folders, only `/`-delimited key prefixes. See [GCS-Specific Notes](#gcs-specific-notes) below.
 
-An additional prefix prepended to the object name. This filters or qualifies the written objects further, for example distinguishing between multiple streams going to the same bucket/prefix.
+#### Object Prefix *(inheritable)*
 
-#### Object Suffix
+An additional prefix prepended to the object name. This can distinguish between multiple streams going to the same bucket/prefix combination.
+
+#### Object Suffix *(inheritable)*
 
 A suffix appended to the object name. Useful for setting file extensions such as `.json` or `.xml`.
 
-#### Content Type
+#### Content Type *(inheritable)*
 
-The MIME type to set on written objects, for example `application/json`. Defaults to `application/octet-stream` if not specified.
+The MIME type to set on written objects. Defaults to `application/octet-stream` if not specified. Example: `application/json`.
 
 #### When Object Already Exists
 
-Defines what happens when an object with the same name already exists in the bucket:
+Defines what happens when an object with the same key already exists in the bucket:
 
 | Option | Behavior |
 |--------|----------|
 | **Transaction rollback** | Fail the transaction and roll back. |
-| **Replace the existing object** | Overwrite the existing object. |
-| **Create a new object using a numerical version counter as suffix** | Write a new object named `<prefix><name>.1`, `<prefix><name>.2`, etc. |
+| **Replace the existing object** | Overwrite the existing object with the new content. |
+| **Create a new object using a numerical version counter as suffix** | Write a new object named `<key>.1`, `<key>.2`, etc. |
 | **Create a new object using the current timestamp as suffix** | Write a new object with a timestamp suffix appended to the name. |
 
-#### Create Sub Folders
+#### Create Sub Folders *(inheritable)*
 
-When enabled, layline.io will create sub folders in the bucket as needed to match the configured prefix path. Disable this if the bucket structure is managed externally.
+When enabled (`true`), layline.io will create intermediate key prefixes in the bucket as needed to match the configured folder prefix path. When disabled (`false`, the default), objects are written directly to the specified prefix without ensuring parent prefixes exist. Disable this if the bucket structure is managed externally.
 
 ### Connection Status
 
-The status bar at the bottom of the Google Cloud Storage Settings panel shows the state of the underlying connection. A green indicator means the connection is active; a red indicator means the connection is unavailable or failed.
+The status bar at the bottom of the Google Cloud Storage Settings panel shows the state of the underlying connection. A green indicator means the connection is active and the bucket list was retrieved successfully. A red indicator means the connection failed or the bucket list could not be retrieved.
+
+## GCS-Specific Notes
+
+### Flat Namespace
+
+GCS does not have a real folder hierarchy. What appear as "folders" in the Google Cloud Console or `gsutil` are simply `/`-delimited prefixes in object keys. For example, the object `logs/2026/03/app.log` is a single object — there is no `logs/` folder that must exist before `logs/2026/03/app.log` can be created.
+
+The **Folder Prefix** and **Create Sub Folders** fields work with these key prefixes, not with a physical directory structure.
+
+### Authentication
+
+GCS Sink uses OAuth 2.0 for authentication — there is no access key / secret key mechanism. The OAuth credentials are defined in the linked Google Cloud Connection asset.
+
+### Project ID vs. Region
+
+Unlike AWS S3, which uses a region, GCS organizes resources by **project**. You must specify the Google Cloud project ID that owns the target bucket. This project must be the same project that the OAuth client in the Google Cloud Connection was created in.
 
 ## Behavior
 
-Each incoming message to this sink produces one object in GCS. The object name is constructed as:
+Each incoming message to this sink produces one object in GCS. The object key is constructed as:
 
 ```
 [<Folder Prefix>/][<Object Prefix>]<message-key>[<Object Suffix>]
 ```
 
-Objects are written with the configured `Content Type`. If `Create Sub Folders` is enabled, missing intermediate folders are created automatically.
-
-## Example
-
-Given this configuration:
+For example, given:
 
 | Field | Value |
 |-------|-------|
@@ -104,14 +125,36 @@ Given this configuration:
 | Folder Prefix | `output/` |
 | Object Prefix | `events-` |
 | Object Suffix | `.json` |
-| Content Type | `application/json` |
-| When Object Already Exists | `Replace the existing object` |
 
 An incoming message with key `order-1234` will be written to GCS as:
 
 ```
 my-gcs-bucket/output/events-order-1234.json
 ```
+
+## Example
+
+Given this configuration:
+
+| Field | Value |
+|-------|-------|
+| Connection | `my-gc-connection` |
+| Project ID | `my-gcp-project` |
+| Bucket Name | `my-gcs-bucket` |
+| Folder Prefix | `output/` |
+| Object Prefix | `events-` |
+| Object Suffix | `.json` |
+| Content Type | `application/json` |
+| When Object Already Exists | `Replace the existing object` |
+| Create Sub Folders | `false` |
+
+An incoming message with key `order-1234` will be written to GCS as:
+
+```
+my-gcs-bucket/output/events-order-1234.json
+```
+
+If an object with that key already exists, it is replaced.
 
 ## See Also
 

--- a/docs/03-assets/sinks/asset-sink-gcs.md
+++ b/docs/03-assets/sinks/asset-sink-gcs.md
@@ -28,10 +28,9 @@ Writes messages to a Google Cloud Storage (GCS) bucket as objects. Each incoming
 
 ![Name & Description (Sink GCS)](.asset-sink-gcs_images/asset-sink-gcs-name-description.png "Name & Description (Sink GCS)")
 
-| Field | Required | Type | Default | Description |
-|-------|----------|------|---------|-------------|
-| Name  | ✓        | String | —      | Unique name for this asset within the project. Spaces are not allowed. |
-| Description | — | String | —      | Optional description of what this sink is used for. |
+**Name** — Unique name for this asset within the project. Spaces are not allowed.
+
+**Description** — Optional description of what this sink is used for.
 
 The **`Asset Usage`** box shows how many times this Asset is used and which parts are referencing it.
 
@@ -47,17 +46,30 @@ The **`Asset Usage`** box shows how many times this Asset is used and which part
 
 ![Google Cloud Storage Settings (Sink GCS)](.asset-sink-gcs_images/asset-sink-gcs-settings.png "Google Cloud Storage Settings (Sink GCS)")
 
-| Field | Required | Type | Default | Description |
-|-------|----------|------|---------|-------------|
-| Connection | ✓ | Reference | — | The [**Google Cloud Connection**](../connections/asset-connection-google-cloud) to use. Must be selected first — all other fields are unavailable until a connection is chosen. |
-| Project ID *(inheritable)* | — | String | — | The Google Cloud project ID that owns the target bucket. |
-| Bucket Name *(inheritable)* | — | String | — | The name of the GCS bucket to write to. Enter as plain text. Bucket existence is not validated at configuration time — it is checked at workflow runtime. |
-| Folder Prefix *(inheritable)* | — | String | — | A path prefix within the bucket under which objects will be written (e.g., `logs/` or `data/output/`). GCS has a flat namespace — see [GCS-Specific Notes](#gcs-specific-notes) for details. |
-| Object Prefix *(inheritable)* | — | String | — | An additional prefix prepended to the object name. Use this to distinguish between multiple streams going to the same bucket/prefix combination. |
-| Object Suffix *(inheritable)* | — | String | — | A suffix appended to the object name. Useful for setting file extensions such as `.json` or `.xml`. |
-| Content Type *(inheritable)* | — | String | `application/octet-stream` | The MIME type to set on written objects. Example: `application/json`. |
-| When Object Already Exists | — | Enum | `Transaction rollback` | What happens when an object with the same key already exists in the bucket. Options: `Transaction rollback` — fail and roll back the transaction; `Replace the existing object` — overwrite it; `Create a new object using a numerical version counter as suffix` — writes `<key>.1`, `<key>.2`, etc.; `Create a new object using the current timestamp as suffix` — appends a timestamp to the key. |
-| Create Sub Folders *(inheritable)* | — | Boolean | `false` | When `true`, layline.io creates intermediate key prefixes in the bucket as needed for the configured folder prefix path. When `false` (default), objects are written directly to the specified prefix. Disable this if the bucket structure is managed externally. |
+**Connection** — The linked Google Cloud Connection asset used for OAuth 2.0 authentication. All other fields below are unavailable until a connection is selected.
+
+**Project ID** — The Google Cloud project ID that owns the target bucket.
+
+**Bucket Name** — The name of the GCS bucket to write to. Not validated at configuration time — checked at workflow runtime.
+
+**Folder Prefix** — A path prefix within the bucket under which objects will be written (e.g., `logs/` or `data/output/`). GCS has a flat namespace — these are key prefixes, not real folders. See [GCS-Specific Notes](#gcs-specific-notes).
+
+**Object Prefix** — An additional prefix prepended to the object name. Useful to distinguish between multiple streams going to the same bucket/prefix combination.
+
+**Object Suffix** — A suffix appended to the object name. Useful for setting file extensions such as `.json` or `.xml`.
+
+**Content Type** — The MIME type to set on written objects. Defaults to `application/octet-stream` if not specified (e.g., `application/json`).
+
+**When Object Already Exists** — What to do when an object with the same key already exists in the bucket:
+
+| Option | Behavior |
+|--------|----------|
+| Transaction rollback | Fail the transaction and roll back. |
+| Replace the existing object | Overwrite the existing object with new content. |
+| Create a new object using a numerical version counter as suffix | Write a new object named `<key>.1`, `<key>.2`, etc. |
+| Create a new object using the current timestamp as suffix | Write a new object with a timestamp suffix appended to the name. |
+
+**Create Sub Folders** — When enabled, layline.io creates intermediate key prefixes in the bucket as needed to match the configured folder prefix path. When disabled (default), objects are written directly to the specified prefix without ensuring parent prefixes exist. Disable this if the bucket structure is managed externally.
 
 The connection status indicator at the bottom of the panel shows whether the selected Google Cloud Connection is active. A green indicator means the connection is working and the bucket list was retrieved. A red indicator means the connection failed.
 

--- a/docs/03-assets/sinks/asset-sink-gcs.md
+++ b/docs/03-assets/sinks/asset-sink-gcs.md
@@ -14,99 +14,85 @@ import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 
 ## Purpose
 
-Writes messages to a Google Cloud Storage (GCS) bucket as objects. Each incoming message produces one object in the configured bucket, under the configured prefix path. Authentication is handled via a linked Google Cloud Connection asset using OAuth 2.0.
+Writes messages to a Google Cloud Storage (GCS) bucket as objects. Each incoming message produces one object in the configured bucket, under the configured prefix path.
 
 ## Prerequisites
 
 - A [**Google Cloud Connection**](../connections/asset-connection-google-cloud) asset configured with the appropriate OAuth scopes.
-- A Google Cloud project with the Google Cloud Storage API enabled.
-- A GCS bucket in that project.
+- A project open in layline.io with the connection created above.
 
 ## Configuration
 
 ### Name & Description
 
-![Name & Description (Sink GCS)](.asset-sink-gcs_images/asset-sink-gcs-name-description.png "Name & Description (Sink GCS)")
+**`Name`** — Unique name for this asset within the project.
 
-**Name** — Unique name for this asset within the project. Spaces are not allowed.
-
-**Description** — Optional description of what this sink is used for.
+**`Description`** — Optional description.
 
 The **`Asset Usage`** box shows how many times this Asset is used and which parts are referencing it.
 
 ### Required Roles
 
-![Required Roles (Sink GCS)](.asset-sink-gcs_images/asset-sink-gcs-required-roles.png "Required Roles (Sink GCS)")
-
 In case you are deploying to a Cluster with Reactive Engine Nodes that have specific Roles configured, you can restrict use of this Asset to Nodes with matching roles. Leave empty to match all Nodes.
 
 ### Google Cloud Storage Settings
 
-![Google Cloud Storage Settings (Sink GCS)](.asset-sink-gcs_images/asset-sink-gcs-settings.png "Google Cloud Storage Settings (Sink GCS)")
+#### Connection
 
-**Connection** — The linked Google Cloud Connection asset used for OAuth 2.0 authentication. Required. The remaining fields cannot be configured until a connection is selected.
+Select a [**Google Cloud Connection**](../connections/asset-connection-google-cloud) from the list. The connection must exist before you can configure the remaining fields.
 
-**Project ID** — The Google Cloud project ID that owns the target bucket.
+#### Project ID
 
-**Bucket Name** — The name of the GCS bucket to write to.
+The Google Cloud project ID that owns the target bucket.
 
-**Folder Prefix** — A path prefix within the bucket under which objects will be written (e.g., `logs/` or `data/output/`). GCS has a flat namespace — these are key prefixes, not real folders. See [GCS-Specific Notes](#gcs-specific-notes).
+#### Bucket Name
 
-**Object Prefix** — An additional prefix prepended to the object name. Useful to distinguish between multiple streams going to the same bucket/prefix combination.
+The name of the GCS bucket to write to. Enter the bucket name as plain text.
 
-**Object Suffix** — A suffix appended to the object name. Useful for setting file extensions such as `.json` or `.xml`.
+#### Folder Prefix
 
-**Content Type** — The MIME type to set on written objects. Defaults to `application/octet-stream` if not specified (e.g., `application/json`).
+A path prefix within the bucket under which objects will be written. For example, `logs/` or `data/output/`. Enter as plain text.
 
-**When Object Already Exists** — What to do when an object with the same key already exists in the bucket.
+#### Object Prefix
+
+An additional prefix prepended to the object name. This filters or qualifies the written objects further, for example distinguishing between multiple streams going to the same bucket/prefix.
+
+#### Object Suffix
+
+A suffix appended to the object name. Useful for setting file extensions such as `.json` or `.xml`.
+
+#### Content Type
+
+The MIME type to set on written objects, for example `application/json`. Defaults to `application/octet-stream` if not specified.
+
+#### When Object Already Exists
+
+Defines what happens when an object with the same name already exists in the bucket:
 
 | Option | Behavior |
 |--------|----------|
-| Transaction rollback | Fail the transaction and roll back. |
-| Replace the existing object | Overwrite the existing object with new content. |
-| Create a new object using a numerical version counter as suffix | Write `<key>.1`, `<key>.2`, etc. |
-| Create a new object using the current timestamp as suffix | Write `<key>.<epoch-timestamp>`. |
+| **Transaction rollback** | Fail the transaction and roll back. |
+| **Replace the existing object** | Overwrite the existing object. |
+| **Create a new object using a numerical version counter as suffix** | Write a new object named `<prefix><name>.1`, `<prefix><name>.2`, etc. |
+| **Create a new object using the current timestamp as suffix** | Write a new object with a timestamp suffix appended to the name. |
 
-**Create Sub Folders** — When enabled, layline.io creates intermediate `/`-delimited key prefixes as needed. Default: disabled.
+#### Create Sub Folders
 
-## GCS-Specific Notes
+When enabled, layline.io will create sub folders in the bucket as needed to match the configured prefix path. Disable this if the bucket structure is managed externally.
 
-### Flat Namespace
+### Connection Status
 
-GCS does not have a real folder hierarchy. What appear as "folders" in the Google Cloud Console or `gsutil` are simply `/`-delimited prefixes in object keys. For example, the object `logs/2026/03/app.log` is a single object — there is no `logs/` folder that must exist before `logs/2026/03/app.log` can be created.
-
-The **Folder Prefix** and **Create Sub Folders** fields work with these key prefixes, not with a physical directory structure.
-
-### Authentication
-
-GCS Sink uses OAuth 2.0 for authentication — there is no access key / secret key mechanism. The OAuth credentials are defined in the linked Google Cloud Connection asset.
-
-### Project ID vs. Region
-
-Unlike AWS S3, which uses a region, GCS organizes resources by **project**. You must specify the Google Cloud project ID that owns the target bucket. This project must be the same project that the OAuth client in the Google Cloud Connection was created in.
+The status bar at the bottom of the Google Cloud Storage Settings panel shows the state of the underlying connection. A green indicator means the connection is active; a red indicator means the connection is unavailable or failed.
 
 ## Behavior
 
-Each incoming message to this sink produces one object in GCS. The object key is constructed as:
+Each incoming message to this sink produces one object in GCS. The object name is constructed as:
 
 ```
 [<Folder Prefix>/][<Object Prefix>]<message-key>[<Object Suffix>]
 ```
 
-For example, given:
-
-| Field | Value |
-|-------|-------|
-| Bucket Name | `my-gcs-bucket` |
-| Folder Prefix | `output/` |
-| Object Prefix | `events-` |
-| Object Suffix | `.json` |
-
-An incoming message with key `order-1234` will be written to GCS as:
-
-```
-my-gcs-bucket/output/events-order-1234.json
-```
+Objects are written with the configured `Content Type`. If `Create Sub Folders` is enabled, missing intermediate folders are created automatically.
 
 ## Example
 
@@ -114,23 +100,18 @@ Given this configuration:
 
 | Field | Value |
 |-------|-------|
-| Connection | `my-gc-connection` |
-| Project ID | `my-gcp-project` |
 | Bucket Name | `my-gcs-bucket` |
 | Folder Prefix | `output/` |
 | Object Prefix | `events-` |
 | Object Suffix | `.json` |
 | Content Type | `application/json` |
 | When Object Already Exists | `Replace the existing object` |
-| Create Sub Folders | `false` |
 
 An incoming message with key `order-1234` will be written to GCS as:
 
 ```
 my-gcs-bucket/output/events-order-1234.json
 ```
-
-If an object with that key already exists, it is replaced.
 
 ## See Also
 

--- a/docs/03-assets/sinks/asset-sink-gcs.md
+++ b/docs/03-assets/sinks/asset-sink-gcs.md
@@ -28,9 +28,10 @@ Writes messages to a Google Cloud Storage (GCS) bucket as objects. Each incoming
 
 ![Name & Description (Sink GCS)](.asset-sink-gcs_images/asset-sink-gcs-name-description.png "Name & Description (Sink GCS)")
 
-**`Name`** — Unique name for this asset within the project. Spaces are not allowed.
-
-**`Description`** — Optional description of what this sink is used for.
+| Field | Required | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| Name  | ✓        | String | —      | Unique name for this asset within the project. Spaces are not allowed. |
+| Description | — | String | —      | Optional description of what this sink is used for. |
 
 The **`Asset Usage`** box shows how many times this Asset is used and which parts are referencing it.
 
@@ -38,60 +39,27 @@ The **`Asset Usage`** box shows how many times this Asset is used and which part
 
 ![Required Roles (Sink GCS)](.asset-sink-gcs_images/asset-sink-gcs-required-roles.png "Required Roles (Sink GCS)")
 
-In case you are deploying to a Cluster with Reactive Engine Nodes that have specific Roles configured, you can restrict use of this Asset to Nodes with matching roles. Leave empty to match all Nodes.
+| Field | Required | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| Required Roles | — | String | — | Restricts use of this Asset to Reactive Engine Nodes with matching Role names. Leave empty to match all Nodes. |
 
 ### Google Cloud Storage Settings
 
 ![Google Cloud Storage Settings (Sink GCS)](.asset-sink-gcs_images/asset-sink-gcs-settings.png "Google Cloud Storage Settings (Sink GCS)")
 
-#### Connection
+| Field | Required | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| Connection | ✓ | Reference | — | The [**Google Cloud Connection**](../connections/asset-connection-google-cloud) to use. Must be selected first — all other fields are unavailable until a connection is chosen. |
+| Project ID *(inheritable)* | — | String | — | The Google Cloud project ID that owns the target bucket. |
+| Bucket Name *(inheritable)* | — | String | — | The name of the GCS bucket to write to. Enter as plain text. Bucket existence is not validated at configuration time — it is checked at workflow runtime. |
+| Folder Prefix *(inheritable)* | — | String | — | A path prefix within the bucket under which objects will be written (e.g., `logs/` or `data/output/`). GCS has a flat namespace — see [GCS-Specific Notes](#gcs-specific-notes) for details. |
+| Object Prefix *(inheritable)* | — | String | — | An additional prefix prepended to the object name. Use this to distinguish between multiple streams going to the same bucket/prefix combination. |
+| Object Suffix *(inheritable)* | — | String | — | A suffix appended to the object name. Useful for setting file extensions such as `.json` or `.xml`. |
+| Content Type *(inheritable)* | — | String | `application/octet-stream` | The MIME type to set on written objects. Example: `application/json`. |
+| When Object Already Exists | — | Enum | `Transaction rollback` | What happens when an object with the same key already exists in the bucket. Options: `Transaction rollback` — fail and roll back the transaction; `Replace the existing object` — overwrite it; `Create a new object using a numerical version counter as suffix` — writes `<key>.1`, `<key>.2`, etc.; `Create a new object using the current timestamp as suffix` — appends a timestamp to the key. |
+| Create Sub Folders *(inheritable)* | — | Boolean | `false` | When `true`, layline.io creates intermediate key prefixes in the bucket as needed for the configured folder prefix path. When `false` (default), objects are written directly to the specified prefix. Disable this if the bucket structure is managed externally. |
 
-Select a [**Google Cloud Connection**](../connections/asset-connection-google-cloud) from the list. This field is required — the remaining fields cannot be configured until a connection is selected.
-
-#### Project ID *(inheritable)*
-
-The Google Cloud project ID that owns the target bucket.
-
-#### Bucket Name *(inheritable)*
-
-The name of the GCS bucket to write to. Enter the bucket name as plain text. The sink does not validate bucket existence at configuration time — this is checked at workflow runtime.
-
-#### Folder Prefix *(inheritable)*
-
-A path prefix within the bucket under which objects will be written. For example: `logs/` or `data/output/`. Enter as plain text.
-
-Note that GCS has a flat namespace — there are no real folders, only `/`-delimited key prefixes. See [GCS-Specific Notes](#gcs-specific-notes) below.
-
-#### Object Prefix *(inheritable)*
-
-An additional prefix prepended to the object name. This can distinguish between multiple streams going to the same bucket/prefix combination.
-
-#### Object Suffix *(inheritable)*
-
-A suffix appended to the object name. Useful for setting file extensions such as `.json` or `.xml`.
-
-#### Content Type *(inheritable)*
-
-The MIME type to set on written objects. Defaults to `application/octet-stream` if not specified. Example: `application/json`.
-
-#### When Object Already Exists
-
-Defines what happens when an object with the same key already exists in the bucket:
-
-| Option | Behavior |
-|--------|----------|
-| **Transaction rollback** | Fail the transaction and roll back. |
-| **Replace the existing object** | Overwrite the existing object with the new content. |
-| **Create a new object using a numerical version counter as suffix** | Write a new object named `<key>.1`, `<key>.2`, etc. |
-| **Create a new object using the current timestamp as suffix** | Write a new object with a timestamp suffix appended to the name. |
-
-#### Create Sub Folders *(inheritable)*
-
-When enabled (`true`), layline.io will create intermediate key prefixes in the bucket as needed to match the configured folder prefix path. When disabled (`false`, the default), objects are written directly to the specified prefix without ensuring parent prefixes exist. Disable this if the bucket structure is managed externally.
-
-### Connection Status
-
-The status bar at the bottom of the Google Cloud Storage Settings panel shows the state of the underlying connection. A green indicator means the connection is active and the bucket list was retrieved successfully. A red indicator means the connection failed or the bucket list could not be retrieved.
+The connection status indicator at the bottom of the panel shows whether the selected Google Cloud Connection is active. A green indicator means the connection is working and the bucket list was retrieved. A red indicator means the connection failed.
 
 ## GCS-Specific Notes
 


### PR DESCRIPTION
Cherry-pick of GCS Connection + GCS Sink docs from doc-restructured-v2 to main.

Files added:
- `docs/03-assets/connections/asset-connection-google-cloud.md` — Google Cloud Connection (OAuth 2.0)
- `docs/03-assets/sinks/asset-sink-gcs.md` — GCS Sink

Commits cherry-picked (from PR #37 and PR #38 on doc-restructured-v2):
- `0eb7156` docs: add Google Cloud Connection and GCS Sink reference docs
- `e1fbe96` docs: enhance Google Cloud Connection and GCS Sink reference docs
- `4d7f2e6` docs: convert GCS Sink Configuration to table format
- `b99d54f` docs: rework GCS Sink field descriptions to bold+description style
- `c12b44f` docs: restyle Google Cloud Connection to bold+description style
- `8ff474e` docs: restyle Google Cloud Connection to bold+description style
- `175deca` fix: remove inheritable markers, fix em-dash placement

Note: Screenshots commit (ac6d533) was already included in initial commit. SKILL.md from 175deca skipped (file doesn't exist on main).
