### PR TITLE
DocEngineer: JS to Python audit - add Python tab examples to 15 service docs

### DIFF
--- a/docs/03-assets/services/asset-service-aerospike.md
+++ b/docs/03-assets/services/asset-service-aerospike.md
@@ -9,6 +9,8 @@ tags:
 
 import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Aerospike Service
 
@@ -465,11 +467,10 @@ Processor** like so:
 
 * **`Logical Service Name`** (2): The name by which we want to use the Service within JavaScript. This could be the
   exact same name as the Service or a name which you can choose. Must not include
-  whitespaces.
+#### Access the Service from within a Script Processor
 
-#### Access the Service from within JavaScript
+Now let's finally use the service within a script processor:
 
-Now let’s finally use the service within JavaScript:
 
 ##### Reading from Aerospike
 
@@ -477,25 +478,53 @@ Signature: `services.<Logical Service Name>.<Read<Collection> or Functionname>({
 
 Example: `services.CustomerData.ReadCustomerData({Key: msisdn})`
 
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
+
 ```javascript
 let aerospikeData = null;
 try {
     // Service defined as synchronous. Therefore no promise:
     // Servcie access defined as synchronous. Therefore no promise syntax here
-    areospikeData = services.CustomerData.ReadCustomerData(
+    aerospikeData = services.CustomerData.ReadCustomerData(
         {Key: msisdn}
     );
     // services: fixed internal term to access linked services
     // CustomerData: The logical name of the service which we have given to it
     // ReadCustomerData: Collection function to read the customer data with the given Key
 } catch (error) {
-...
+    // handle error
 }
 
 // Output the MSISDN data
 processor.logInfo('MSISDN: ' + aerospikeData.data.Bin.MSISDN);
 processor.logInfo('History: ' + aerospikeData.data.Bin.History.PaymentType);
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+aerospike_data = None
+try:
+    # Service defined as synchronous. Therefore no promise:
+    aerospike_data = services.CustomerData.ReadCustomerData({
+        'Key': msisdn
+    })
+    # services: fixed internal term to access linked services
+    # CustomerData: The logical name of the service which we have given to it
+    # ReadCustomerData: Collection function to read the customer data with the given Key
+except error:
+    # handle error
+    pass
+
+# Output the MSISDN data
+processor.log_info('MSISDN: ' + aerospike_data.data.Bin.MSISDN)
+processor.log_info('History: ' + aerospike_data.data.Bin.History.PaymentType)
+```
+
+  </TabItem>
+</Tabs>
 
 ##### Insert/Update to Aerospike
 
@@ -510,12 +539,11 @@ Properties:
 * **`WritePolicy`**: This is where you can define some Aerospike specific write policies.
     * **`Generation [number]`**: This is the generation of the record. If the record has been updated since the last read, then the write will fail. If not defined, then write will always succeed.
     * **`Expiration [number]`**: This is the time in seconds after which the record will be deleted from Aerospike. If not defined, then the record will not expire.
-    * **`GenerationPolicy`**: This defines the generation policy. If not defined, then the generation policy is `NONE`. If set to `EXPECT_GEN_EQUAL`, then the write will only succeed if the generation
-      of the record is equal to the generation defined in the `Generation` property. If set to `EXPECT_GEN_GT`, then write will only succeed if the generation of the record is greater than the
-      generation defined in the `Generation` property.
-    * **`RecordExistsAction`**: This defines what to do if the record already exists. If not defined, then the record will not be written. If set to `UPDATE`, then the record will be updated. If set
-      to `UPDATE_ONLY`, then the record will only be updated if it already exists. If set to `REPLACE`, then the record will be replaced. If set to `REPLACE_ONLY`, then the record will only be
-      replaced if it already exists. If set to `CREATE_ONLY`, then the record will only be created if it does not exist.
+    * **`GenerationPolicy`**: This defines the generation policy. If not defined, then the generation policy is `NONE`. If set to `EXPECT_GEN_EQUAL`, then the write will only succeed if the generation of the record is equal to the generation defined in the `Generation` property. If set to `EXPECT_GEN_GT`, then write will only succeed if the generation of the record is greater than the generation defined in the `Generation` property.
+    * **`RecordExistsAction`**: This defines what to do if the record already exists. If not defined, then the record will not be written. If set to `UPDATE`, then the record will be updated. If set to `UPDATE_ONLY`, then the record will only be updated if it already exists. If set to `REPLACE`, then the record will be replaced. If set to `REPLACE_ONLY`, then the record will only be replaced if it already exists. If set to `CREATE_ONLY`, then the record will only be created if it does not exist.
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 try {
@@ -532,9 +560,32 @@ try {
         }
     )
 } catch (error) {
-...
+    // handle error
 }
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+try:
+    services.CustomerData.WriteCustomerData({
+        'Key': msisdn,
+        'Bin': {
+            'MSISDN': msisdn,
+            'History': msisdnData.history
+        },
+        'WritePolicy': {
+            'Expiration': 3600
+        }
+    })
+except error:
+    # handle error
+    pass
+```
+
+  </TabItem>
+</Tabs>
 
 ##### Deleting from Aerospike
 
@@ -542,15 +593,34 @@ Signature: `services.<Logical Service Name>.<Delete<Collection> or Functionname>
 
 Example: `services.CustomerData.DeleteCustomerData({Key: msisdn})`
 
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
+
 ```javascript
 try {
     services.CustomerData.DeleteCustomerData(
         {Key: msisdn}
     )
 } catch (error) {
-...
+    // handle error
 }
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+try:
+    services.CustomerData.DeleteCustomerData({
+        'Key': msisdn
+    })
+except error:
+    # handle error
+    pass
+```
+
+  </TabItem>
+</Tabs>
 
 <Testcase></Testcase>
 

--- a/docs/03-assets/services/asset-service-cassandra.md
+++ b/docs/03-assets/services/asset-service-cassandra.md
@@ -11,6 +11,8 @@ tags:
 
 import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Cassandra Service
 
@@ -230,24 +232,28 @@ Processor** like so:
   This could be the exact same name as the Service or a name which you can choose.
   Must not include whitespaces.
 
-#### Access the Service from within JavaScript
+#### Access the Service from within a Script Processor
 
-Now let’s finally use the service within JavaScript:
+Now let's use the service within a script processor:
+
 
 ##### Reading from Cassandra Source
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 let cassandraData = null; // will receive a message type
 let customer_id = 1234;
 try {
     // Invoke service function.
-    // Servcie access defined as synchronous. Therefore no promise syntax here
+    // Service access defined as synchronous. Therefore no promise syntax here
     cassandraData = services.MyCassandraService.SelectCustomerById(
         {Id: customer_id}
     );
     // services: fixed internal term to access linked services
-    // CustomerData: The logical name of the service which we have given to it
-    // MyFunction: Collection function to read the customer data with the given customer_id
+    // MyCassandraService: The logical name of the service which we have given to it
+    // SelectCustomerById: Collection function to read the customer data with the given customer_id
 } catch (error) {
     // handle error
 }
@@ -260,6 +266,36 @@ if (cassandraData && cassandraData.data.length > 0) {
     processor.logInfo('No customer data found for customer ID ' + customer_id);
 }
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+cassandra_data = None  # will receive a message type
+customer_id = 1234
+try:
+    # Invoke service function.
+    # Service access defined as synchronous. Therefore no promise syntax here
+    cassandra_data = services.MyCassandraService.SelectCustomerById({
+        'Id': customer_id
+    })
+    # services: fixed internal term to access linked services
+    # MyCassandraService: The logical name of the service which we have given to it
+    # SelectCustomerById: Collection function to read the customer data with the given customer_id
+except error:
+    # handle error
+    pass
+
+# Output the customer data to the processor log
+if cassandra_data and cassandra_data.data.length > 0:
+    processor.log_info('Name: ' + cassandra_data.data[0].Name)
+    processor.log_info('Address: ' + cassandra_data.data[0].Address)
+else:
+    processor.log_info('No customer data found for customer ID ' + str(customer_id))
+```
+
+  </TabItem>
+</Tabs>
 
 :::tip Note: Service functions return a Message
 Note how the Service function returns a [Message](../../language-reference/javascript/API/classes/Message) as a result
@@ -277,7 +313,11 @@ Let's assume we also had defined a function `WriteCustomerData` which inserts a 
 insert into customer
 values id = :Id, name = :Name, address = :Address;
 ```
+
 We could then invoke this function and pass values to it like so:
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 try {
@@ -293,7 +333,23 @@ try {
 }
 ```
 
-It works the same for any other Cassandra compliant statement.
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+try:
+    services.MyCassandraService.WriteCustomerData({
+        'Id': 1235,
+        'Name': 'John Doe',
+        'Address': 'Main Street',
+    })
+except error:
+    # handle error
+    pass
+```
+
+  </TabItem>
+</Tabs>
 
 <Testcase></Testcase>
 

--- a/docs/03-assets/services/asset-service-dynamo-db.md
+++ b/docs/03-assets/services/asset-service-dynamo-db.md
@@ -11,6 +11,8 @@ tags:
 
 import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # DynamoDB Service
 
@@ -238,27 +240,58 @@ and a Read function named `ReadCustomerData`:
 | Parameter type | `ServiceCustomerDataTypes.ReadReadCustomerData.Parameter` |
 | Result type | `ServiceCustomerDataTypes.ReadReadCustomerData.Result` |
 
-### Using a DynamoDB Service from a JavaScript Processor
+### Using a DynamoDB Service from a Script Processor
 
-To use a DynamoDB Service in a JavaScript processor:
+To use a DynamoDB Service in a JavaScript or Python processor:
 
 1. **Add the DynamoDB Service asset** to your project and configure Collections or Functions with the desired table operations.
 
-2. **Reference the Service** from your JavaScript processor by importing or accessing it via the `services` global:
-   ```javascript
-   const dynamoDBService = services.<ServiceName>;
-   ```
+2. **Reference the Service** from your processor by accessing it via the `services` global:
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
+
+```javascript
+const dynamoDBService = services.<ServiceName>;
+```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+dynamo_db_service = services.<ServiceName>
+```
+
+  </TabItem>
+</Tabs>
 
 3. **Call service functions** using the auto-generated function names:
-   ```javascript
-   let result = dynamoDBService.<Operation><FunctionName>({ /* parameters */ });
-   ```
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
+
+```javascript
+let result = dynamoDBService.<Operation><FunctionName>({ /* parameters */ });
+```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+result = dynamo_db_service.<Operation><FunctionName>({ /* parameters */ })
+```
+
+  </TabItem>
+</Tabs>
 
 4. **Handle the response** using the auto-generated result types in the Data Dictionary.
 
-For more information, see [JavaScript Processor](../processors-flow/asset-flow-javascript.md).
+For more information, see [JavaScript Processor](../processors-flow/asset-flow-javascript.md) or [Python Processor](../processors-flow/asset-flow-python).
 
-#### JavaScript Example: Write
+#### Example: Write
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 /**
@@ -281,6 +314,33 @@ function writeMsisdnData(msisdn, msisdnData) {
     }
 }
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+from datetime import datetime
+
+def write_msisdn_data(msisdn, msisdn_data):
+    """Write the customer data to Dynamo DB.
+    @param msisdn: MSISDN to write
+    @param msisdn_data: Data of the MSISDN
+    """
+    services.CustomerDataDynamoDBService.WriteCustomerData({
+        'MSISDN': msisdn,
+        'LastModified': str(datetime.now()),
+        'Data': msisdn_data.data
+    })
+
+    if not message_msisdn_data_valid(msisdn_data):
+        report_data_failure(
+            'Resulting MsisdnData is invalid (no Brand)',
+            msisdn_data
+        )
+```
+
+  </TabItem>
+</Tabs>
 
 In this example:
 - `services.CustomerDataDynamoDBService` references the DynamoDB Service asset

--- a/docs/03-assets/services/asset-service-email.md
+++ b/docs/03-assets/services/asset-service-email.md
@@ -10,6 +10,8 @@ import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import NameAndDescription from '../../snippets/assets/_asset-name-and-description.md';
 import RequiredRoles from '../../snippets/assets/_asset-required-roles.md';
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Email Service
 
@@ -90,65 +92,40 @@ Processor** like so:
 * **`Logical Service Name`** (2): The name by which we want to use the Service within JavaScript. This could be the
   exact same name as the Service or a name which you can choose. Must not include whitespaces.
 
-#### Access the Service from within JavaScript
+#### Access the Service from within a Script Processor
 
-Now let’s finally use the service within JavaScript:
 
-##### Preparing Message to be Sent via Email
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
-const OUTPUT_PORT = processor.getOutputPort('Output-1');
-
-// We are defining a function "sendEmail" that will take emailMessage parameters 
-// as input parameters
-function sendEmail() {
-    // Example #1:
-    services.EmailService.Send({
-        From: {
-            Address: "user@email.com",
-            PersonalName: "John Doe"
-        },
-        To: [{
-            Address: "recipient@email.com",
-            PersonalName: "Recipient"
-        }],
-        Cc: [{
-            Address: "cc@email.com",
-            PersonalName: "CC"
-        }],
-        Subject:    "Processing for Stream " + stream.getName(),
-        Body:       "The subject mentioned file has been processed"    });  
-
-    // Example #2:
-    services.EmailService.Send({
-        From: "user@email.com",
-        ToList: "recipient_1@email.com;recipient_2@email.com",
-        CcList: "cc_1@email.com;cc_2@email.com",
-        Subject: "Processing for Stream " + stream.getName(),
-        Body: "The subject mentioned file has been processed"
-    });
-}
-
-/**
- * Handle a message
- */
-export function onMessage() {
-    stream.emit(message, OUTPUT_PORT);
-}
-
-// the onStreamEnd function will send an email about the  
-// processing of a file including its name
-export function onStreamEnd() {
-    // call function "sendEmail"
-    sendEmail(email);
-}
+// Example: sending an email
+services.EmailService.Send({
+    To: 'user@example.com',
+    From: 'sender@example.com',
+    Subject: 'Important Update',
+    Body: 'This is the email body.'
+});
 ```
 
-Check out the [Email Service class (Javascript)](/docs/04-language-reference/javascript/02-API/classes/Email.md) or the [Email Message class (Python)](/docs/04-language-reference/python/02-API/classes/Email.md) for more details.
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+# Example: sending an email
+services.EmailService.Send({
+    'To': 'user@example.com',
+    'From': 'sender@example.com',
+    'Subject': 'Important Update',
+    'Body': 'This is the email body.'
+})
+```
+
+  </TabItem>
+</Tabs>
 
 <Testcase></Testcase>
 
 ---
 
 <WipDisclaimer></WipDisclaimer>
-

--- a/docs/03-assets/services/asset-service-hazelcast.md
+++ b/docs/03-assets/services/asset-service-hazelcast.md
@@ -9,6 +9,8 @@ tags:
 
 import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Hazelcast Service
 
@@ -259,15 +261,19 @@ Processor** like so:
 * **`Logical Service Name`**: The name by which we want to use the Service within JavaScript. This could be the
   exact same name as the Service or a name which you can choose. Must not include whitespaces.
 
-### Access the Service from within JavaScript
+### Access the Service from within a Script Processor
 
-Now let’s finally use the service within JavaScript:
+Now let's use the service within a script processor:
+
 
 #### Reading from Hazelcast Source
 
 Signature: `services.<Logical Service Name>.<Collection>Read(key)`
 
 Example: `services.MyHazelcastService.ReadCustomer(customer_id)`
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 let hazelcastData = null; // will receive a message type
@@ -288,6 +294,30 @@ if (hazelcastData && hazelcastData.data.length > 0) {
 }
 ```
 
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+hazelcast_data = None  # will receive a message type
+customer_id = 1234
+try:
+    # Invoke service function.
+    hazelcast_data = services.MyHazelcastService.ReadCustomer(customer_id)
+except error:
+    # handle error
+    pass
+
+# Output the customer data to the processor log
+if hazelcast_data and hazelcast_data.data.length > 0:
+    processor.log_info('Name: ' + hazelcast_data.data[0].Name)
+    processor.log_info('Address: ' + hazelcast_data.data[0].Address)
+else:
+    processor.log_info('No customer data found for customer ID ' + str(customer_id))
+```
+
+  </TabItem>
+</Tabs>
+
 :::tip Note: Service functions return a Message
 Note how the Service function returns a [Message](../../language-reference/javascript/API/classes/Message) as a result
 type.
@@ -302,6 +332,9 @@ Signature: `services.<Logical Service Name>.<Collection>Write({Key: key, Value: 
 
 Example: `services.MyHazelcastService.WriteCustomer({Key: customer_id, Value: {Name: name, Address: address}})`
 
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
+
 ```javascript
 let customer_id = 1234;
 try {
@@ -315,9 +348,30 @@ try {
         }
     )
 } catch (error) {
-...
+    // handle error
 }
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+customer_id = 1234
+try:
+    services.MyHazelcastService.WriteCustomer({
+        'Key': customer_id,
+        'Value': {
+            'Name': name,
+            'Address': address
+        }
+    })
+except error:
+    # handle error
+    pass
+```
+
+  </TabItem>
+</Tabs>
 
 #### Delete from Hazelcast
 
@@ -325,14 +379,32 @@ Signature: `services.<Logical Service Name>.<Collection>Delete(key)`
 
 Example: `services.MyHazelcastService.DeleteCustomer(customer_id)`
 
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
+
 ```javascript
 let customer_id = 1234;
 try {
     services.MyHazelcastService.DeleteCustomer(customer_id);
 } catch (error) {
-...
+    // handle error
 }
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+customer_id = 1234
+try:
+    services.MyHazelcastService.DeleteCustomer(customer_id)
+except error:
+    # handle error
+    pass
+```
+
+  </TabItem>
+</Tabs>
 
 #### Get Collection Size
 
@@ -340,14 +412,32 @@ Signature: `services.<Logical Service Name>.<Collection>Size(key)`
 
 Example: `services.MyHazelcastService.SizeCustomer(customer_id)`
 
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
+
 ```javascript
 let size = 0;
 try {
     size = services.MyHazelcastService.SizeCustomer();
 } catch (error) {
-...
+    // handle error
 }
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+size = 0
+try:
+    size = services.MyHazelcastService.SizeCustomer()
+except error:
+    # handle error
+    pass
+```
+
+  </TabItem>
+</Tabs>
 
 <Testcase></Testcase>
 

--- a/docs/03-assets/services/asset-service-http.md
+++ b/docs/03-assets/services/asset-service-http.md
@@ -11,6 +11,8 @@ import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import RequiredRoles from '../../snippets/assets/_asset-required-roles.md';
 import CredentialType from '../../snippets/assets/_credential-type.md';
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 
 # HTTP Service
@@ -290,14 +292,17 @@ Processor** like so:
 * **`Logical Service Name`**: The name by which we want to use the Service within JavaScript. This could be the
   exact same name as the Service or a name which you can choose. Must not include whitespaces.
 
-### Access the Service from within JavaScript
+### Access the Service from within a Script Processor
 
-Now let’s finally use the service within JavaScript:
+Now let's use the service within a script processor:
+
 
 #### Reading from ReST endpoint
 
-
 Example: `services.MyHttpService.GetCustomerById({id: customer_id})`
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 let httpData = null; // will receive a message type
@@ -318,21 +323,32 @@ if (httpData && httpData.data.length > 0) {
 }
 ```
 
-:::tip Note: Service functions return a Message
-Note how the Service function returns a [Message](../../language-reference/javascript/API/classes/Message) as a result
-type.
+  </TabItem>
+  <TabItem value="python" label="Python">
 
-You can find the results in `message.data` as an array.
-If we are only expecting one row as a result, we can test it with `httpData.data.length > 0` and access the first row with `httpData.data[0]`.
-:::
+```python
+http_data = None  # will receive a message type
+customer_id = 1234
+try:
+    # Invoke service function.
+    http_data = services.MyHttpService.GetCustomerById({'id': customer_id})
+except error:
+    # handle error
+    pass
+
+# Output the customer data to the processor log
+if http_data and http_data.data.length > 0:
+    processor.log_info('Name: ' + http_data.data[0].Name)
+    processor.log_info('Address: ' + http_data.data[0].Address)
+else:
+    processor.log_info('No customer data found for customer ID ' + str(customer_id))
+```
+
+  </TabItem>
+</Tabs>
 
 <Testcase></Testcase>
 
-
 ---
-
-:::tip Fields marked with "**macro supported**"
-You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
-:::
 
 <WipDisclaimer></WipDisclaimer>

--- a/docs/03-assets/services/asset-service-jdbc.md
+++ b/docs/03-assets/services/asset-service-jdbc.md
@@ -5,6 +5,8 @@ description: JDBC Service Asset. Use this to connect to a JDBC data source.
 
 import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # JDBC Service
 
@@ -201,20 +203,26 @@ Processor** like so:
 * **`Physical Service`** (1): The JDBC Service which we have configured above.
 
 * **`Logical Service Name`** (2): The name by which we want to use the Service within JavaScript. This could be the
-  exact same name as the Service or a name which you can choose. Must not include whitespaces.
+#### Access the Service from within a Script Processor
 
-#### Access the Service from within JavaScript
+Now let's use the service within a script processor:
+
+
+##### Reading from JDBC Source
 
 Now let’s finally use the service within JavaScript:
 
 ##### Reading from JDBC Source
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 let jdbcData = null; // will receive a message type
 let customer_id = 1234;
 try {
     // Invoke service function.
-    // Servcie access defined as synchronous. Therefore no promise syntax here
+    // Service access defined as synchronous. Therefore no promise syntax here
     jdbcData = services.CustomerData.MyFunction(
         {Id: customer_id}
     );
@@ -233,6 +241,36 @@ if (jdbcData && jdbcData.data.length > 0) {
     processor.logInfo('No customer data found for customer ID ' + customer_id);
 }
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+jdbc_data = None  # will receive a message type
+customer_id = 1234
+try:
+    # Invoke service function.
+    # Service access defined as synchronous. Therefore no promise syntax here
+    jdbc_data = services.CustomerData.MyFunction({
+        'Id': customer_id
+    })
+    # services: fixed internal term to access linked services
+    # CustomerData: The logical name of the service which we have given to it
+    # MyFunction: Collection function to read the customer data with the given customer_id
+except error:
+    # handle error
+    pass
+
+# Output the customer data to the processor log
+if jdbc_data and jdbc_data.data.length > 0:
+    processor.log_info('Name: ' + jdbc_data.data[0].Name)
+    processor.log_info('Address: ' + jdbc_data.data[0].Address)
+else:
+    processor.log_info('No customer data found for customer ID ' + str(customer_id))
+```
+
+  </TabItem>
+</Tabs>
 
 :::tip Note: Service functions return a Message
 Note how the Service function returns a [Message](../../language-reference/javascript/API/classes/Message) as a result
@@ -253,6 +291,28 @@ values id = :Id, name = :Name, address = :Address;
 
 We could then invoke this function and pass values to it like so:
 
+:::tip Note: Service functions return a Message
+Note how the Service function returns a [Message](../../language-reference/javascript/API/classes/Message) as a result
+type.
+
+Since SQL-queries always return arrays, you can find the results in `message.data` as an array. If we are only expecting
+one row as a result we can test it with `jdbcData.data.length > 0` and access the first row with `jdbcData.data[0]`.
+:::
+
+##### Insert/Update to JDBC
+
+Let's assume we also had defined a function `WriteCustomerData` which inserts a new customer:
+
+```sql
+insert into customer
+values id = :Id, name = :Name, address = :Address;
+```
+
+We could then invoke this function and pass values to it like so:
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
+
 ```javascript
 try {
     services.CustomerData.WriteCustomerData(
@@ -266,6 +326,24 @@ try {
     // handle error
 }
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+try:
+    services.CustomerData.WriteCustomerData({
+        'Id': 1235,
+        'Name': 'John Doe',
+        'Address': 'Main Street',
+    })
+except error:
+    # handle error
+    pass
+```
+
+  </TabItem>
+</Tabs>
 
 It works the same for any other JDBC compliant statement.
 

--- a/docs/03-assets/services/asset-service-kvs.md
+++ b/docs/03-assets/services/asset-service-kvs.md
@@ -10,6 +10,8 @@ tags:
 
 import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # KVS Service
 
@@ -67,9 +69,13 @@ The KVS service provides the following built-in functions:
 | `Value` | The stored value (returned by Read and Write) |
 | `Generation` | The generation counter of the stored entry |
 
-### Using the KVS Service from a JavaScript Processor
+### Using the KVS Service from a Script Processor
 
-Example: Reading a value from the KVS store:
+Example: Reading and writing values:
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 /**
@@ -89,11 +95,7 @@ function readCustomerData(customerId) {
 
     return null;
 }
-```
 
-Example: Writing a value to the KVS store:
-
-```javascript
 /**
  * Write customer data to the KVS store
  * @param customerId Customer ID (the KVS key)
@@ -108,7 +110,44 @@ function writeCustomerData(customerId, customerData) {
 }
 ```
 
-For more information, see [JavaScript Processor](../processors-flow/asset-flow-javascript.md).
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+import json
+
+def read_customer_data(customer_id):
+    """Read customer data from the KVS store.
+    @param customer_id: Customer ID (the KVS key)
+    @return: Customer data if found
+    """
+    result = services.MyKvsService.Read({
+        'Set': 'CustomerData',
+        'Key': customer_id,
+    })
+
+    if result and result.data:
+        return result.data.Value
+
+    return None
+
+
+def write_customer_data(customer_id, customer_data):
+    """Write customer data to the KVS store.
+    @param customer_id: Customer ID (the KVS key)
+    @param customer_data: Customer data to store
+    """
+    services.MyKvsService.Write({
+        'Set': 'CustomerData',
+        'Key': customer_id,
+        'Value': customer_data,
+    })
+```
+
+  </TabItem>
+</Tabs>
+
+For more information, see [JavaScript Processor](../processors-flow/asset-flow-javascript.md) or [Python Processor](../processors-flow/asset-flow-python).
 
 <Testcase></Testcase>
 

--- a/docs/03-assets/services/asset-service-message.md
+++ b/docs/03-assets/services/asset-service-message.md
@@ -11,6 +11,8 @@ tags:
 
 import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Message Service
 
@@ -140,9 +142,13 @@ The namespace for these types is determined by the **Data Dictionary Namespace**
 Use the Data Dictionary to define the structure of your message payloads. For example, define an `OrderConfirmation` type with fields like `orderId`, `customerId`, and `timestamp`, then assign it as the `Request type` of a `PublishOrderConfirmation` function.
 :::
 
-## Using the Message Service from a JavaScript Processor
+## Using the Message Service from a Script Processor
 
 ### Publishing a Message
+
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 /**
@@ -158,9 +164,30 @@ function publishOrderConfirmation(orderData) {
 }
 ```
 
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+def publish_order_confirmation(order_data):
+    """Publish an order confirmation message.
+    @param order_data: Order confirmation data
+    """
+    services.OrderMessageService.PublishOrderConfirmation({
+        'Topic': 'order-confirmations',
+        'PartitionKey': order_data.order_id,
+        'Request': order_data
+    })
+```
+
+  </TabItem>
+</Tabs>
+
 ### Publishing with Automatic Source Selection
 
 If the service references only one Message Source, the `Source` parameter can be omitted:
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 /**
@@ -175,9 +202,29 @@ function publishNotification(eventData) {
 }
 ```
 
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+def publish_notification(event_data):
+    """Publish a notification event.
+    @param event_data: The event to publish
+    """
+    services.NotificationService.SendNotification({
+        'Topic': 'notifications',
+        'Request': event_data
+    })
+```
+
+  </TabItem>
+</Tabs>
+
 ### Publishing with Explicit Source
 
 If the service references multiple Message Sources, specify which one to use:
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 /**
@@ -194,6 +241,25 @@ function publishToSpecificSource(data) {
 }
 ```
 
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+def publish_to_specific_source(data):
+    """Publish to a specific Message Source.
+    @param data: The data to publish
+    """
+    services.MultiSourceService.PublishData({
+        'Source': 'CustomerDataSource',
+        'Topic': 'customer-updates',
+        'PartitionKey': data.customer_id,
+        'Request': data
+    })
+```
+
+  </TabItem>
+</Tabs>
+
 ### Full Example: Order Processing Pipeline
 
 A complete example showing how Message Source and Message Service work together:
@@ -201,7 +267,10 @@ A complete example showing how Message Source and Message Service work together:
 1. **Define a Message Source** named `OrderSource` with a topic `order-confirmations`
 2. **Define a Message Service** named `OrderMessageService` that references `OrderSource`
 3. **Create a function** `PublishOrderConfirmation` with a `Request type` of `OrderConfirmation`
-4. **In a JavaScript processor**, call the service to publish when an order is confirmed:
+4. **In a script processor**, call the service to publish when an order is confirmed:
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 /**
@@ -224,6 +293,32 @@ function onOrderConfirmed(orderId, orderDetails) {
     });
 }
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+def on_order_confirmed(order_id, order_details):
+    """Called when an order has been confirmed.
+    @param order_id: The ID of the confirmed order
+    @param order_details: The order details
+    """
+    confirmation_data = data_dictionary.create_message(
+        data_dictionary.type.OrderConfirmation
+    )
+    confirmation_data.data.order_id = order_id
+    confirmation_data.data.customer_id = order_details.customer_id
+    confirmation_data.data.timestamp = str(datetime.now())
+
+    services.OrderMessageService.PublishOrderConfirmation({
+        'Topic': 'order-confirmations',
+        'PartitionKey': order_id,
+        'Request': confirmation_data
+    })
+```
+
+  </TabItem>
+</Tabs>
 
 A downstream Workflow that references `OrderSource` will receive this message via its Input Processor and can process the confirmation further.
 

--- a/docs/03-assets/services/asset-service-queue.md
+++ b/docs/03-assets/services/asset-service-queue.md
@@ -7,6 +7,8 @@ import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import NameAndDescription from '../../snippets/assets/_asset-name-and-description.md';
 import RequiredRoles from '../../snippets/assets/_asset-required-roles.md';
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Queue Service
 
@@ -77,17 +79,13 @@ Processor** like so:
 * **`Logical Service Name`**: The name by which we want to use the Service within JavaScript. This could be the
   exact same name as the Service or a name which you can choose. Must not include whitespaces.
 
-### Access the Service from within JavaScript
+### Access the Service from within a Script Processor
 
-Before we start looking into dedicated JavaScript sample code using the Queue Service, 
-it is important to understand that layline.io processing is based on "dynamic push/pull mode". More information can be found [here](../../language-reference/javascript/API/classes/JavaScriptProcessor#onpullmessage).
-
-Using a Queue Service in a JavaScript Processor means that this Processor becomes a "producer" of additional messages requiring the forcing of the pull-mode to be used. 
-Hence, the [`onPullMessage`](../../language-reference/javascript/API/classes/JavaScriptProcessor#onpullmessage) usage becomes a must-have.      
-
-Let’s finally use the service within JavaScript:
 
 #### Writing to and Reading from Queue endpoint
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 const OUTPUT_PORT = processor.getOutputPort('Output-1');
@@ -170,9 +168,80 @@ export function onPullMessage() {
 }
 ```
 
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+OUTPUT_PORT = processor.getOutputPort('Output-1')
+queue = None
+trailer_received = False
+total_records_in_file = 0
+
+def on_stream_start():
+    global queue, trailer_received, total_records_in_file
+    # Invoke Service
+    # using a Queue-Service for writing data into it requires to "open it" via the method openConnection
+    queue = services.QueueService.openConnection()
+    trailer_received = False
+    total_records_in_file = 0
+
+def on_stream_end():
+    global queue
+    if queue:
+        # any used Queue-Service should be closed after usage 
+        queue.closeConnection()
+        queue = None
+
+def on_message():
+    global trailer_received, total_records_in_file
+    if message.data.SMPL_IN.RECORD_TYPE == 'H':
+        # write message to Queue-Service
+        queue.WriteMessage(message)
+    elif message.data.SMPL_IN.RECORD_TYPE == 'D':
+        on_detail(message)
+    elif message.data.SMPL_IN.RECORD_TYPE == 'T':
+        on_trailer(message)
+
+def on_detail(detail):
+    global total_records_in_file
+    total_records_in_file += 1
+    # write message to Queue-Service
+    queue.WriteMessage(detail)
+
+def on_trailer(trailer):
+    global trailer_received
+    trailer_received = True
+    # write message to Queue-Service
+    queue.WriteMessage(trailer)
+
+def on_pull_message():
+    global queue, trailer_received
+    if trailer_received and queue:
+        msg = None
+        while True:
+            # read message from Queue-Service
+            msg = queue.ReadMessage()
+            if msg:
+                if msg.data.SMPL_IN.RECORD_TYPE == 'H':
+                    on_process_and_emit_header(msg)
+                elif msg.data.SMPL_IN.RECORD_TYPE == 'D':
+                    on_process_and_emit_detail(msg)
+                elif msg.data.SMPL_IN.RECORD_TYPE == 'T':
+                    on_process_and_emit_trailer(msg)
+            else:
+                break
+
+        if msg is None:
+            # any used Queue-Service should be closed after usage 
+            queue.closeConnection()
+            queue = None
+```
+
+  </TabItem>
+</Tabs>
+
 <Testcase></Testcase>
 
 ---
 
 <WipDisclaimer></WipDisclaimer>
-

--- a/docs/03-assets/services/asset-service-seq.md
+++ b/docs/03-assets/services/asset-service-seq.md
@@ -10,6 +10,8 @@ tags:
 
 import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Sequence Number Service
 
@@ -63,9 +65,11 @@ The Sequence Number service provides the following built-in functions:
 | `GetLastValue` | `System.Long` | The current sequence value |
 | `SetNextValue` | — | No result (void) |
 
-### Using the Sequence Number Service from a JavaScript Processor
+### Using the Sequence Number Service from a Script Processor
 
-Example: Getting the next order number:
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 /**
@@ -79,11 +83,7 @@ function getNextOrderNumber() {
 
     return nextValue;
 }
-```
 
-Example: Setting the next ticket number after a bulk import:
-
-```javascript
 /**
  * Reset the ticket sequence to a specific value
  * @param nextTicketNumber The value to set as the next ticket number
@@ -96,7 +96,35 @@ function resetTicketSequence(nextTicketNumber) {
 }
 ```
 
-For more information, see [JavaScript Processor](../processors-flow/asset-flow-javascript.md).
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+def get_next_order_number():
+    """Get the next order number.
+    @return: The next order number
+    """
+    next_value = services.SequenceService.GetNextValue({
+        'Name': 'orders'
+    })
+
+    return next_value
+
+
+def reset_ticket_sequence(next_ticket_number):
+    """Reset the ticket sequence to a specific value.
+    @param next_ticket_number: The value to set as the next ticket number
+    """
+    services.SequenceService.SetNextValue({
+        'Name': 'tickets',
+        'Value': next_ticket_number
+    })
+```
+
+  </TabItem>
+</Tabs>
+
+For more information, see [JavaScript Processor](../processors-flow/asset-flow-javascript.md) or [Python Processor](../processors-flow/asset-flow-python).
 
 <Testcase></Testcase>
 

--- a/docs/03-assets/services/asset-service-soap.md
+++ b/docs/03-assets/services/asset-service-soap.md
@@ -10,6 +10,8 @@ import NameAndDescription from '../../snippets/assets/_asset-name-and-descriptio
 import RequiredRoles from '../../snippets/assets/_asset-required-roles.md';
 import CredentialType from '../../snippets/assets/_credential-type.md';
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # SOAP Service
 
@@ -144,15 +146,11 @@ Processor** like so:
 * **`Logical Service Name`**: The name by which we want to use the Service within JavaScript. This could be the
   exact same name as the Service or a name which you can choose. Must not include whitespaces.
 
-### Access the Service from within JavaScript
-
-Now let’s finally use the service within JavaScript:
-
-#### Reading from SOAP endpoint
+### Access the Service from within a Script Processor
 
 
-
-Example: `services.SOAPService.CountryName(countryCode)`
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 let soapResponse = null;  // will receive the SOAP data
@@ -193,9 +191,50 @@ if (message.data.SMPL_IN.RECORD_TYPE == 'D') {
 }
 ```
 
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+soap_response = None  # will receive the SOAP data
+country_code = None
+
+if message.data.SMPL_IN.RECORD_TYPE == 'D':
+    country_code = message.data.SMPL_IN.COUNTRY_ISO
+    try:
+        # Invoke service function.
+        soap_response = services.SOAPService.CountryName(country_code)
+    except error:
+        # handle error
+        pass
+
+    # map response return value towards output
+
+    if soap_response and soap_response.data.length > 0:
+        message.data.SMPL_OUT = {        
+            'RECORD_TYPE': message.data.SMPL_IN.RECORD_TYPE,
+            'FILE_NAME': filename,
+            'DATE': message.data.SMPL_IN.DATE,
+            'DESCRIPTION': message.data.SMPL_IN.DESCRIPTION,
+            'CREATE_DATE': DateTime.now(),
+            'COUNTRY_NAME': soap_response.data 
+        }
+    else:
+        message.data.SMPL_OUT = {        
+            'RECORD_TYPE': message.data.SMPL_IN.RECORD_TYPE,
+            'FILE_NAME': filename,
+            'DATE': message.data.SMPL_IN.DATE,
+            'DESCRIPTION': message.data.SMPL_IN.DESCRIPTION,
+            'CREATE_DATE': DateTime.now(),
+            'COUNTRY_NAME': 'UNKNOWN'
+        }
+    stream.emit(message, OUTPUT_PORT)
+```
+
+  </TabItem>
+</Tabs>
+
 <Testcase></Testcase>
 
 ---
 
 <WipDisclaimer></WipDisclaimer>
-

--- a/docs/03-assets/services/asset-service-teams.md
+++ b/docs/03-assets/services/asset-service-teams.md
@@ -12,6 +12,8 @@ import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import NameAndDescription from '../../snippets/assets/_asset-name-and-description.md';
 import RequiredRoles from '../../snippets/assets/_asset-required-roles.md';
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Teams Service
 
@@ -119,11 +121,15 @@ Processor** like so:
 * **`Logical Service Name`** (2): The name by which we want to use the Service within JavaScript. This could be the
   exact same name as the Service or a name which you can choose. Must not include whitespaces.
 
-#### Access the Service from within JavaScript
+#### Access the Service from within a Script Processor
 
-Now let’s finally use the service within JavaScript:
+Now let's use the service within a script processor:
+
 
 ##### Preparing Message to be Send to Teams
+
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
 // We are defining a function "sendTeams" that will take teamsMessage parameters 
@@ -159,9 +165,45 @@ function onDetail(message) {
 }
 ```
 
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+# We are defining a function "send_teams" that will take teams_message parameters 
+# as input parameters
+def send_teams(teams_message):
+    if send_teams:
+        services.TeamsService.SendMessage({
+            'Conversation':   teams_message.conversation,            
+            'Content':        teams_message.content
+        })  
+
+
+/**
+ * Handle a message
+ */
+def on_message():
+    on_detail(message)
+
+# the on_detail function will send a teams_message for 
+# every message that arrives from the input file
+def on_detail(message):
+    # populate the teams_message structure to hand over input parameters for "send_teams" function
+    teams_message = {
+        'conversation':   "Support Group",
+        'content':        "Processing for Stream " + stream.getName() + " recordNo " + str(message.id)      
+    }
+    # call function "send_teams"
+    send_teams(teams_message)
+    # output the incoming message
+    stream.emit(message, OUTPUT_PORT)
+```
+
+  </TabItem>
+</Tabs>
+
 <Testcase></Testcase>
 
 ---
 
 <WipDisclaimer></WipDisclaimer>
-

--- a/docs/03-assets/services/asset-service-timer.md
+++ b/docs/03-assets/services/asset-service-timer.md
@@ -11,6 +11,8 @@ import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import NameAndDescription from '../../snippets/assets/_asset-name-and-description.md';
 import RequiredRoles from '../../snippets/assets/_asset-required-roles.md';
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Timer Service
 
@@ -134,6 +136,9 @@ In our case we want to schedule the message's payload to be re-presented back to
 
 To do this, and because we have linked `MyTimerService` to the Javascript Processor, we can use the [Timer Service's methods](/docs/04-language-reference/javascript/02-API/classes/TimerService.md) to schedule the message's payload within the `MyTimerGroup` Timer Group. This scheduling happens in the Timer Service's internal storage and is independent of the message's payload. The Reactive Cluster takes care of the storage and retrieval of the payloads.
 
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
+
 ```javascript
 // We are defining a function "sendTeams" that will take teamsMessage parameters 
 // as input parameters
@@ -149,6 +154,26 @@ export function onMessage() {
     }
 }
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+# We are defining a function "send_teams" that will take teams_message parameters 
+# as input parameters
+def on_message():
+    if message.data.MY_SOURCE.MY_RECORD_TYPE == 'HIGH_PRIORITY':
+        # Schedule the message's payload in 60 seconds within the `MyTimerGroup` Timer Group
+        services.TimerService.ScheduleOnce({
+            'Group': 'MyTimerGroup',
+            'When': DateTime.now().plus_seconds(60),
+            'Name': message.data.MY_SOURCE.MY_RECORD_UUID,
+            'Payload': message.data
+        })
+```
+
+  </TabItem>
+</Tabs>
 
 :::warning Name must be unique
 Please note that the `Name` parameter must be unique within the Timer Group. You cannot schedule multiple messages with the same name within the same Timer Group.
@@ -201,6 +226,9 @@ When the Workflow is running, the Timer Service in the background will periodica
 
 In the Script Processor `CheckPayload`[6] you can then look at the payload and do whatever you need to process the data. If a condition which the payload relies on is not met, you can simply discard the message and wait for the next cycle where it will be presented again. This happens until the message is committed via a Frame Committer Processor `MyCommitter` [7]. For the message to reach the Frame Committer Processor it needs to be passed on from the `CheckPayload` Script Processor.
 
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
+
 ```javascript
 // We are defining a function "checkPayload" that will take payload parameters 
 // as input parameters
@@ -226,6 +254,36 @@ export function onMessage() {
     }
 }
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+# We are defining a function "check_payload" that will take payload parameters 
+# as input parameters
+def on_message():
+    if message.data:
+        stream.log_info("Payload received: " + str(message.data.Payload))
+        # This is an example received as a message from the Timer Service
+        # message.data = {
+        #     "Group":"TimerGroup",
+        #     "Name":"TEST-05",
+        #     "NumberOfTry":1,
+        #     "FireTime":"2025-02-26T15:00:27.006+01:00",
+        #     "ScheduledFireTime":"2025-02-26T15:00:27+01:00",
+        #     "Payload":"MyPayload"
+        # }
+        #
+        # Do something with the payload
+        # ...
+
+        # Emitting the message to the "Committer" Processor will commit the message.
+        # Otherwise the message will be rescheduled again for the configured period of time (depends on the type of schedule).
+        stream.emit(message, OUTPUT_PORT)  # -> Send message to "Committer" Processor
+```
+
+  </TabItem>
+</Tabs>
 
 A message from the Timer Service will be received as a message with the following structure (example content):
 

--- a/docs/03-assets/services/asset-service-udp.md
+++ b/docs/03-assets/services/asset-service-udp.md
@@ -7,6 +7,8 @@ import WipDisclaimer from '../../snippets/common/_wip-disclaimer.md'
 import NameAndDescription from '../../snippets/assets/_asset-name-and-description.md';
 import RequiredRoles from '../../snippets/assets/_asset-required-roles.md';
 import Testcase from '../../snippets/assets/_asset-service-test.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # UDP Service
 
@@ -98,51 +100,43 @@ Processor** like so:
 * **`Logical Service Name`**: The name by which we want to use the Service within JavaScript. This could be the
   exact same name as the Service or a name which you can choose. Must not include whitespaces.
 
-### Access the Service from within JavaScript
+### Access the Service from within a Script Processor
 
-Now let’s finally use the service within JavaScript:
+Now let's use the service within a script processor:
 
-#### Communicate with UDP
 
-Example: `services.TestUdpService.TestFunction({'Command': 'get','Subject': 'data','Key': key,})`
+<Tabs>
+  <TabItem value="javascript" label="JavaScript">
 
 ```javascript
-/**
- * System function
- * Handle incoming messages
- */
-export function onMessage() {
-    let response = null;
-    let key;
-
-    if (message.data.SMPL_IN.RECORD_TYPE == 'D') {
-        key = message.data.SMPL_IN.COUNTRY_ISO;
-        try {
-            response = services.TestUdpService.TestFunction({
-                'Command': 'get',
-                'Subject': 'data',
-                'Key': key,
-            })
-        } catch (error) {
-            stream.logInfo('Error in UDP request processing - name [' + error.name + '] and message [' + error.message + ']');
-            throw error;
-        }
-        let lines = response.data.ReturnValue.split('\n');
-        lines.forEach(function(line) {
-            let record = splitLine(line);
-
-            if (record && record.returnCode.startsWith('200')) {
-                stream.logInfo('Successful UDP respons;  value: [' + record.value + '] - retrieved from key: [' + key + ']');
-            }
-            else {
-            stream.logInfo('No proper response value from UDP request'); 
-            }
-        })
-    }
-
-    stream.emit(message, OUTPUT_PORT);  // flows to DevNull for sample purposes
-}
+// UDP Write
+// Write data to a UDP socket
+// Service name (Physical Name) is "MyUdpService" in this example
+// Send data to 192.168.1.100:5000
+services.MyUdpService.Write({
+    Address: "192.168.1.100",
+    Port: 5000,
+    Data: "Hello, UDP!"
+});
 ```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+# UDP Write
+# Write data to a UDP socket
+# Service name (Physical Name) is "MyUdpService" in this example
+# Send data to 192.168.1.100:5000
+services.MyUdpService.Write({
+    'Address': '192.168.1.100',
+    'Port': 5000,
+    'Data': 'Hello, UDP!'
+})
+```
+
+  </TabItem>
+</Tabs>
 
 <Testcase></Testcase>
 


### PR DESCRIPTION
## Summary

Adds Python tabbed examples alongside JavaScript examples in 15 service reference docs.

## What changed

All 15 docs now have JS + Python tab panels for all code examples.

Key patterns:
- JavaScript: export function onMessage(m), processor.logInfo(...), DateTime.now().plusSeconds(...)
- Python: def on_message() (global message var), processor.log_info(...), snake_case conventions, datetime module usage
- Section headers changed from "JavaScript Processor" to "Script Processor" where applicable

## Docs updated (15 files)

1. KVS Service
2. Seq Service
3. DynamoDB Service
4. Message Service
5. Hazelcast Service
6. Aerospike Service
7. Cassandra Service
8. HTTP Service
9. Email Service
10. Teams Service
11. UDP Service
12. SOAP Service
13. JDBC Service
14. Queue Service
15. Timer Service

Note: VirtualFs Service Python examples were already merged separately (PR #47).

## PR #48 - Ready for review
