### PR TITLE
LAY-9: Replace hardcoded Data Dictionary Card sections with snippet

### DIFF
--- a/docs/03-assets/01-workflow-assets/formats/03-asset-format-data-dictionary.md
+++ b/docs/03-assets/01-workflow-assets/formats/03-asset-format-data-dictionary.md
@@ -8,6 +8,7 @@ tags:
 ---
 
 import WipDisclaimer from '../../../snippets/common/_wip-disclaimer.md'
+import DataDictionaryCardDetails from '../../../snippets/assets/data-dictionary-card.md';
 
 # Data Dictionary Format
 
@@ -98,17 +99,7 @@ This can occur when elements of that format are being referenced in a Workflow, 
 
 ### Format Types
 
-This is where you actually define your specific Data Dictionary itself.
-Remember that a Data Dictionary basically is a tree of elements with specific names and types.
-Types may reference other types within this Data Dictionary, or from another Data Dictionary (which stems from another format definition, e.g. Generic Format, etc.).
-
-Use the following dialog to define this tree.
-
-<div className="frame">
-
-![Format types (Format Data Dictionary)](.03-asset-format-data-dictionary_images/da98aee2.png)
-
-</div>
+<DataDictionaryCardDetails />
 
 #### Example
 

--- a/docs/03-assets/01-workflow-assets/formats/03-asset-format-http.md
+++ b/docs/03-assets/01-workflow-assets/formats/03-asset-format-http.md
@@ -8,6 +8,7 @@ tags:
 ---
 
 import WipDisclaimer from '../../../snippets/common/_wip-disclaimer.md'
+import DataDictionaryCardDetails from '../../../snippets/assets/data-dictionary-card.md';
 
 # Http Format
 
@@ -166,17 +167,7 @@ This can occur when elements of that format are being referenced in a Workflow, 
 
 ### Format Types
 
-This is where you actually define your specific Data Dictionary itself.
-Remember that a Data Dictionary basically is a tree of elements with specific names and types.
-Types may reference other types within this Data Dictionary, or from another Data Dictionary (which stems from another format definition, e.g. Generic Format, etc.).
-
-Use the following dialog to define this tree.
-
-<div className="frame">
-
-![Format types (Format Data Dictionary)](.03-asset-format-data-dictionary_images/da98aee2.png)
-
-</div>
+<DataDictionaryCardDetails />
 
 #### Example
 


### PR DESCRIPTION
## Summary

Replaces hardcoded generic Data Dictionary Card UI descriptions in two Format Asset docs with the snippet import.

**Files changed (2):**
- `docs/03-assets/01-workflow-assets/formats/03-asset-format-data-dictionary.md`
- `docs/03-assets/01-workflow-assets/formats/03-asset-format-http.md`

**What was removed:** Generic paragraph describing the Data Dictionary tree editor UI (toolbar, tree view, entity operations) and a screenshot.

**What was preserved:** Step-by-step tutorials (e.g., Example: PowerEnum, EngineType, Vehicle Type) are kept as asset-specific HOW-TO content.

## Scope analysis (per Andrew review feedback)

Verified all 9 source files using DataDictionaryCard.vue:

| Source | Doc | Action |
|---|---|---|
| FormatDataDictionaryEditor.vue | 03-asset-format-data-dictionary.md | In this PR |
| HttpServiceEditor.vue | 03-asset-format-http.md | In this PR |
| DynamoDbServiceEditor.vue | asset-service-dynamo-db.md | No — conceptual only |
| JdbcServiceEditor.vue | asset-service-jdbc.md | No — tutorial walkthrough |
| CassandraServiceEditor.vue | asset-service-cassandra.md | No — conceptual only |
| AerospikeServiceEditor.vue | asset-service-aerospike.md | No — brief mention only |
| HazelcastServiceEditor.vue | asset-service-hazelcast.md | No — brief mention only |
| MessageServiceEditor.vue | asset-service-message.md | No — conceptual only |
| DataDictionaryResourceEditor.vue | asset-resource-data-dictionary-updates.md | No — brief mention + link |

Service docs contain contextual or tutorial content, not generic UI reference. Please confirm if further scope expansion is needed.

**Build:** passes

Linear: https://linear.app/layline/issue/LAY-9
