### PR TITLE
LAY-30: Replace bespoke Data Dictionary sections with shared snippet

### DIFF
--- a/docs/03-assets/01-workflow-assets/resources/asset-resource-data-dictionary-updates.md
+++ b/docs/03-assets/01-workflow-assets/resources/asset-resource-data-dictionary-updates.md
@@ -29,8 +29,6 @@ For full details of supported element types (Namespace, Sequence, Choice, Enumer
 
 **`Description`**: Enter a description.
 
-### Format Types
-
 <DataDictionaryCard />
 
 ## Example

--- a/docs/03-assets/01-workflow-assets/resources/asset-resource-data-dictionary-updates.md
+++ b/docs/03-assets/01-workflow-assets/resources/asset-resource-data-dictionary-updates.md
@@ -4,6 +4,7 @@ description: Data Dictionary Updates Resource. Extend the global Data Dictionary
 ---
 
 import WipDisclaimer from '../../../snippets/common/_wip-disclaimer.md'
+import DataDictionaryCard from '../../../snippets/assets/data-dictionary-card.md';
 
 # Data Dictionary Updates
 
@@ -30,37 +31,7 @@ For full details of supported element types (Namespace, Sequence, Choice, Enumer
 
 ### Format Types
 
-The Format Types section provides the Data Dictionary tree editor — the same component used by the [Data Dictionary Format](../formats/03-asset-format-data-dictionary.md). It allows you to declare, organize, and maintain a hierarchy of custom type definitions.
-
-#### Tree Navigation
-
-Each node represents a declared type. Click a node to select it and view or edit its details in the right panel.
-
-#### Context Menu
-
-Right-click a node (or click the dropdown button) to access:
-
-- **Add sibling** — adds a new type at the same level as the selected node
-- **Add child** — adds a child type beneath the selected node (only available for types that support children, e.g. Namespace, Sequence, Choice)
-- **Delete** — removes the type from this Asset
-
-Deleted types can be reset to their parent definition using the reset button that appears on the node.
-
-#### Entity Detail Panel
-
-When a node is selected, the right panel shows its fields:
-
-**`Name`**: The type's name. Must be unique within the same parent.
-
-**`Type`**: The element type. Dropdown options include: `Namespace`, `Sequence`, `Choice`, `Enumeration`, `Array`, `Map`. Changing the type clears all previously declared members.
-
-**`Description`**: Free-text description of the type.
-
-Additional fields appear depending on the selected type (e.g., members table for Sequence/Choice, element list for Enumeration, contained type for Array/Map). See the [Data Dictionary Format](../formats/03-asset-format-data-dictionary.md) documentation for full details on all type-specific configuration options.
-
-#### Root Types
-
-Click **+ DECLARE ROOT TYPE** at the bottom of the tree to add a new top-level type declaration. Root types are not scoped under a parent Namespace.
+<DataDictionaryCard />
 
 ## Example
 

--- a/docs/03-assets/01-workflow-assets/services/asset-service-aerospike.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-aerospike.md
@@ -11,6 +11,7 @@ import WipDisclaimer from '../../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../../snippets/assets/_asset-service-test.md';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import DataDictionaryCard from '../../../snippets/assets/data-dictionary-card.md';
 
 # Aerospike Service
 
@@ -365,82 +366,7 @@ and  `History` with a simple and complex type.
 
 ### Data Dictionary
 
-The Data Dictionary allows us to define complex data structures which can be mapped onto Aerospike data types (e.g.
-String).
-
-As an example, let’s configure the `History` Bin from our example above. The `History` Bin is a more complex type in
-that it contains data formatted in JSON. In Aerospike this is simply stored as a
-String. In layline.io, however, we want to be able to access the individual data within that JSON format as individual
-fields. To solve this, we can define our own data types using the Data Dictionary
-which reflects the JSON format stored in Aerospike and vice versa.
-
-```json
-{
-  "History": [
-    {
-      "ValidFrom": "2021",
-      "ValidTo": "2021",
-      "Provider": "XYZ",
-      "PaymentType": "PT"
-    }
-  ]
-} 
-```
-
-Let’s define this custom data type using the Data Dictionary:
-
-1. Declare namespace
-2. Declare `History`
-
-**Declare a new type (1):**
-
-![](.asset-service-aerospike_images/2e2039d9.png "Declare new Data Dictionary type (Service Aerospike)")
-
-##### 1. Declare namespace
-
-To better organize data types, we declare a namespace first:
-
-![](.asset-service-aerospike_images/92925da1.png "Declare namespace (Service Aerospike)")
-
-* **`Name`** (1): The name of the element.
-  If you are configuring a namespace, and you reuse the name of a namespace, which you have created elsewhere in this
-  Project, then the elements of the namespaces will be merged into the namespace by
-  this same name.
-  Otherwise the name must be unique and may not contain spaces.
-
-* **`Type`** (2): Pick the type of the element. In our example we first define a namespace. When we define additional
-  elements under that namespace we will pick any of the other data types to actually
-  hold the data.
-
-* **`Description`** (3): Anything which describes the element further.
-
-##### 2. Declare History
-
-Add a child to the namespace we just created:
-
-![](.asset-service-aerospike_images/527bde2c.png "Add child to namespace (Service Aerospike)")
-
-* Click the small arrow next to the namespace name (1)
-* Select `Add child` to add a child element to the namespace
-* Fill in the details:
-
-![](.asset-service-aerospike_images/3fc6c30e.png "Configure History element (Service Aerospike)")
-
-* **`Name`** (1): Name the element `History`
-
-* **`Type`** (2): Select `Sequence` as the element type. In the next step we will create individual members of the
-  sequence.
-
-* **`Extendable Sequence`** (3): Leave this unchecked for the example. If checked, it allows you and layline.io to
-  dynamically extend the list of sequence members while working with the data type
-  which we are defining. If - for example - your incoming data format has additional fields which are not defined in the
-  sequence, the sequence will be automatically extended by these fields.
-
-Now we add a list of member fields which make up the sequence (1):
-
-![](.asset-service-aerospike_images/a0b969a9.png "Add sequence members (Service Aerospike)")
-
-To later reference the `ValidFrom` field, we can use the path `MyNamespace.History.ValidFrom`, and so forth.
+<DataDictionaryCard />
 
 ### Example: Using the Aerospike Service
 

--- a/docs/03-assets/01-workflow-assets/services/asset-service-aerospike.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-aerospike.md
@@ -364,8 +364,6 @@ a Collection.
 We now have defined a Collection which references an Aerospike `Namespace`, `Set`, and two `Bins` `MSISDN`
 and  `History` with a simple and complex type.
 
-### Data Dictionary
-
 <DataDictionaryCard />
 
 ### Example: Using the Aerospike Service

--- a/docs/03-assets/01-workflow-assets/services/asset-service-cassandra.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-cassandra.md
@@ -13,6 +13,7 @@ import WipDisclaimer from '../../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../../snippets/assets/_asset-service-test.md';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import DataDictionaryCard from '../../../snippets/assets/data-dictionary-card.md';
 
 # Cassandra Service
 
@@ -136,73 +137,7 @@ As you can see from the example above, you can use [Macros](../../../language-re
 
 ### Data Dictionary
 
-The Data Dictionary allows us to define complex data structures which can be mapped onto Cassandra data types and vice versa.
-For this purpose, we need to define an internal custom data type which can receive the results of the statement, and/or
-also provide data for other parts of the statement, e.g. for the `where`-clause as in our example.
-
-As an example, let’s do this for the above CQL-Statement accessing the `customer` table. What do we need here?
-
-1. We are selecting five fields `ìd`, `name`, `address`, `phone` and `email` from that table.
-   So we need three corresponding fields in our own data dictionary that we can map these results to.
-2. We query based on an `id` (of the customer).
-   We need to map an internal Id field from the data dictionary to the `where`-clause in the CQL-Statement.
-   For this purpose, we can use the same data structure as for 1., which already contains an Id field.
-
-Let's define the necessary custom data type using the data dictionary:
-
-1. Declare a new type
-2. Declare namespace (optional)
-3. Declare Sequence `Customer`
-
-##### 1. Declare a new type (1):
-
-![](.asset-service-cassandra_images/c229e3d3.png "Declare type (Service Cassandra)")
-
-##### 2. Declare namespace
-
-![](.asset-service-cassandra_images/dbc9cd93.png "Declare namespace (Service Cassandra)")
-
-To better organize data types, we declare a namespace first (optional):
-
-* **`Name`** (1): The name of the element.
-  If you are configuring a namespace, and you reuse the name of a namespace, which you have created elsewhere in this
-  Project, then the elements of the namespaces will be merged into the namespace by
-  this same name.
-  Otherwise the name must be unique and may not contain spaces.
-
-* **`Type`** (2): Pick the type of the element. In our example we first define a namespace. When we define additional
-  elements under that namespace we will pick any of the other data types to actually
-  hold the data.
-
-* **`Description`** (3): Anything which describes the element further.
-
-##### 3. Declare Customer Sequence
-
-Add a child to the namespace we just created:
-
-![](.asset-service-cassandra_images/4dc870f5.png "Add child to namespace (Service Cassandra)")
-
-* Click the small arrow next to the namespace name (1)
-* Select `Add child` to add a child element to the namespace
-* Fill in the details:
-
-![](.asset-service-cassandra_images/8ef0360d.png "Declare customer structure (Service Cassandra)")
-
-* **`Name`** (1): Name the element `History`
-
-* **`Type`** (2): Select `Sequence` as the element type. In the next step we will create individual members of the
-  sequence.
-
-* **`Extendable Sequence`** (3): Leave this unchecked for the example. If checked, it allows you and layline.io to
-  dynamically extend the list of sequence members while working with the data type
-  which we are defining. If - for example - your incoming data format has additional fields which are not defined in the
-  sequence, the sequence will be automatically extended by these fields.
-
-Now we add a list of member fields which make up the sequence (1):
-
-![](.asset-service-cassandra_images/234657f1.png "Customer sequence members (Service Cassandra)")
-
-To later reference the `Name` field, we can use the path `MyCorp.Customer.Name`, and so forth.
+<DataDictionaryCard />
 
 ### Example: Using the Cassandra Service
 

--- a/docs/03-assets/01-workflow-assets/services/asset-service-cassandra.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-cassandra.md
@@ -135,8 +135,6 @@ Please note that the notation follows [HOCON format](https://www.w3schools.io/fi
 As you can see from the example above, you can use [Macros](../../../language-reference/macros) within the Typesafe Configuration.
 :::
 
-### Data Dictionary
-
 <DataDictionaryCard />
 
 ### Example: Using the Cassandra Service

--- a/docs/03-assets/01-workflow-assets/services/asset-service-dynamo-db.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-dynamo-db.md
@@ -12,6 +12,7 @@ tags:
 import WipDisclaimer from '../../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../../snippets/assets/_asset-service-test.md';
 import Tabs from '@theme/Tabs';
+import DataDictionaryCard from '../../../snippets/assets/data-dictionary-card.md';
 import TabItem from '@theme/TabItem';
 
 # DynamoDB Service
@@ -186,25 +187,7 @@ Note: `Use AWS null attribute` for Value mapping is only available when `Attribu
 
 ### Data Dictionary
 
-The Data Dictionary editor allows you to define custom data types used by the Service's Functions and Collections.
-These types specify the structure of request parameters and response data for DynamoDB operations.
-
-The namespace for these types is determined by the **Target data dictionary namespace** setting.
-If not specified, it defaults to `Service{Name}Types` (e.g., `ServiceCustomerDataTypes`).
-
-For example, if your Service is named `CustomerData` and your namespace is `ServiceCustomerDataTypes`, a
-Read function's parameter type would be `ServiceCustomerDataTypes.ReadCustomerData.Parameter` and its result type
-would be `ServiceCustomerDataTypes.ReadCustomerData.Result`.
-
-Define types using the Data Dictionary editor. Each type consists of members that map to DynamoDB attributes
-via the attribute mapping configuration.
-
-:::tip
-The Data Dictionary section is available directly within the DynamoDB Service editor, allowing you to create and manage
-types in context while configuring your table mappings.
-:::
-
-![DynamoDB Data Dictionary](./.asset-service-dynamo-db_images/05-data-dictionary.png)
+<DataDictionaryCard />
 
 ### Auto-Generated Function Names
 

--- a/docs/03-assets/01-workflow-assets/services/asset-service-dynamo-db.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-dynamo-db.md
@@ -185,8 +185,6 @@ Note: `Use AWS null attribute` for Value mapping is only available when `Attribu
 
 ![DynamoDB Attribute Mapping](./.asset-service-dynamo-db_images/04-attribute-mapping.png)
 
-### Data Dictionary
-
 <DataDictionaryCard />
 
 ### Auto-Generated Function Names

--- a/docs/03-assets/01-workflow-assets/services/asset-service-hazelcast.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-hazelcast.md
@@ -167,8 +167,6 @@ Following in the table, define the fields which are defined within the Portable 
 
 Create additional Portable Types that you want to work with within layline.io.
 
-### Data Dictionary
-
 <DataDictionaryCard />
 
 ## Example: Using the Hazelcast Service

--- a/docs/03-assets/01-workflow-assets/services/asset-service-hazelcast.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-hazelcast.md
@@ -11,6 +11,7 @@ import WipDisclaimer from '../../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../../snippets/assets/_asset-service-test.md';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import DataDictionaryCard from '../../../snippets/assets/data-dictionary-card.md';
 
 # Hazelcast Service
 
@@ -166,74 +167,9 @@ Following in the table, define the fields which are defined within the Portable 
 
 Create additional Portable Types that you want to work with within layline.io.
 
-### Service Types
+### Data Dictionary
 
-In this section, you define the data types which you wan to map Hazelcast Collections to/from.
-
-The Data Dictionary allows us to define complex data structures which can be mapped onto Hazelcast Collections and vice versa.
-For this purpose, we need to define an internal custom data type which can receive the results of the statement, and/or
-which we want to insert/update within the Collection.
-
-As an example, let’s do this for the above Collection `Customer`. What do we need here?
-
-1. The Collection contains a structure with three fields `ìd`, `name` and `address`.
-   So we need three corresponding fields in our own data dictionary that we can map these results to.
-
-Let's define the necessary custom data type using the data dictionary:
-
-1. Declare a new type
-2. Declare namespace (optional)
-3. Declare Sequence `Customer`
-
-##### 1. Declare a new type (1):
-
-![](.asset-service-hazelcast_images/cb57846b.png "Declare type (Service Hazelcast)")
-
-##### 2. Declare namespace
-
-To better organize data types, we declare a namespace first (optional):
-
-![](.asset-service-hazelcast_images/eb7d381f.png "Declare namespace (Service Hazelcast)")
-
-* **`Name`** (1): The name of the element.
-  If you are configuring a namespace, and you reuse the name of a namespace, which you have created elsewhere in this
-  Project, then the elements of the namespaces will be merged into the namespace by
-  this same name.
-  Otherwise the name must be unique and may not contain spaces.
-
-* **`Type`** (2): Pick the type of the element. In our example we first define a namespace. When we define additional
-  elements under that namespace we will pick any of the other data types to actually
-  hold the data.
-
-* **`Description`** (3): Anything which describes the element further.
-
-##### 3. Declare Customer Sequence
-
-Add a child to the namespace we just created:
-
-![](.asset-service-hazelcast_images/4efa05a7.png "Add child to namespace (Service Hazelcast)")
-
-* Click the small arrow next to the namespace name (1)
-* Select `Add child` to add a child element to the namespace
-* Fill in the details:
-
-![](.asset-service-hazelcast_images/88cf6280.png "Declare customer structure (Service Hazelcast)")
-
-* **`Name`** (1): Name the element `History`
-
-* **`Type`** (2): Select `Sequence` as the element type. In the next step we will create individual members of the
-  sequence.
-
-* **`Extendable Sequence`** (3): Leave this unchecked for the example. If checked, it allows you and layline.io to
-  dynamically extend the list of sequence members while working with the data type
-  which we are defining. If - for example - your incoming data format has additional fields which are not defined in the
-  sequence, the sequence will be automatically extended by these fields.
-
-Now we add a list of member fields which make up the sequence:
-
-![](.asset-service-hazelcast_images/8f3746e9.png "Customer sequence members (Service Hazelcast)")
-
-To later reference the `Name` field, we can use the path `MyNamespace.Customer.Name`, and so forth.
+<DataDictionaryCard />
 
 ## Example: Using the Hazelcast Service
 

--- a/docs/03-assets/01-workflow-assets/services/asset-service-http.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-http.md
@@ -13,6 +13,7 @@ import CredentialType from '../../../snippets/assets/_credential-type.md';
 import Testcase from '../../../snippets/assets/_asset-service-test.md';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import DataDictionaryCard from '../../../snippets/assets/data-dictionary-card.md';
 
 
 # HTTP Service
@@ -264,6 +265,10 @@ A new Response will be added to the list of Responses, and you can now define th
 * **`Description`**: A description of the Response.
 
 ![](.asset-service-http_images/2023-11-27-21.png "Response Definition (Service Http)")
+
+### Data Dictionary
+
+<DataDictionaryCard />
 
 ## Example: Using the Http Service
 

--- a/docs/03-assets/01-workflow-assets/services/asset-service-http.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-http.md
@@ -266,8 +266,6 @@ A new Response will be added to the list of Responses, and you can now define th
 
 ![](.asset-service-http_images/2023-11-27-21.png "Response Definition (Service Http)")
 
-### Data Dictionary
-
 <DataDictionaryCard />
 
 ## Example: Using the Http Service

--- a/docs/03-assets/01-workflow-assets/services/asset-service-jdbc.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-jdbc.md
@@ -7,6 +7,7 @@ import WipDisclaimer from '../../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../../snippets/assets/_asset-service-test.md';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import DataDictionaryCard from '../../../snippets/assets/data-dictionary-card.md';
 
 # JDBC Service
 
@@ -111,73 +112,7 @@ Next fill out the details:
 
 ### Data Dictionary
 
-The Data Dictionary allows us to define complex data structures which can be mapped onto JDBC data types and vice versa.
-For this purpose, we need to define an internal custom data type which can receive the results of the statement, and/or
-also provide data for other parts of the statement, e.g. for the `where`-clause as in our example.
-
-As an example, let’s do this for the above SQL-Statement accessing the `customer` table. What do we need here?
-
-1. We are selecting three fields `ìd`, `name` and `address` from that table. So we need three corresponding fields in
-   our own data dictionary that we can map these results to.
-2. We query based on an `id` (of the customer). We need to map an internal Id field from the data dictionary to
-   the `where`-clause in the SQL-Statement. For this purpose we can use the same data structure as for 1., which already
-   contains an Id field.
-
-Let's define the necessary custom data type using the data dictionary:
-
-1. Declare a new type
-2. Declare namespace (optional)
-3. Declare Sequence `Customer`
-
-##### 1. Declare a new type (1):
-
-![](.asset-service-jdbc_images/0cd537d7.png "Declare type (Service JDBC)")
-
-##### 2. Declare namespace
-
-To better organize data types, we declare a namespace first (optional):
-
-![](.asset-service-jdbc_images/9182150d.png "Declare namespace (Service JDBC)")
-
-* **`Name`** (1): The name of the element.
-  If you are configuring a namespace, and you reuse the name of a namespace, which you have created elsewhere in this
-  Project, then the elements of the namespaces will be merged into the namespace by
-  this same name.
-  Otherwise the name must be unique and may not contain spaces.
-
-* **`Type`** (2): Pick the type of the element. In our example we first define a namespace. When we define additional
-  elements under that namespace we will pick any of the other data types to actually
-  hold the data.
-
-* **`Description`** (3): Anything which describes the element further.
-
-##### 3. Declare Customer Sequence
-
-Add a child to the namespace we just created:
-
-![](.asset-service-jdbc_images/14576d88.png "Add child to namespace (Service JDBC)")
-
-* Click the small arrow next to the namespace name (1)
-* Select `Add child` to add a child element to the namespace
-* Fill in the details:
-
-![](.asset-service-jdbc_images/5821cb89.png "Declare customer structure (Service JDBC)")
-
-* **`Name`** (1): Name the element `History`
-
-* **`Type`** (2): Select `Sequence` as the element type. In the next step we will create individual members of the
-  sequence.
-
-* **`Extendable Sequence`** (3): Leave this unchecked for the example. If checked, it allows you and layline.io to
-  dynamically extend the list of sequence members while working with the data type
-  which we are defining. If - for example - your incoming data format has additional fields which are not defined in the
-  sequence, the sequence will be automatically extended by these fields.
-
-Now we add a list of member fields which make up the sequence (1):
-
-![](.asset-service-jdbc_images/5ad3f74a.png "Customer sequence members (Service JDBC)")
-
-To later reference the `Name` field, we can use the path `MyNamespace.Customer.Name`, and so forth.
+<DataDictionaryCard></DataDictionaryCard>
 
 ### Example: Using the JDBC Service
 

--- a/docs/03-assets/01-workflow-assets/services/asset-service-jdbc.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-jdbc.md
@@ -110,8 +110,6 @@ Next fill out the details:
   always preceded with `result.` and then followed by the member name. On the right hand side, enter the original field
   names used in your SQL-Statement.
 
-### Data Dictionary
-
 <DataDictionaryCard></DataDictionaryCard>
 
 ### Example: Using the JDBC Service

--- a/docs/03-assets/01-workflow-assets/services/asset-service-message.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-message.md
@@ -12,6 +12,7 @@ tags:
 import WipDisclaimer from '../../../snippets/common/_wip-disclaimer.md'
 import Testcase from '../../../snippets/assets/_asset-service-test.md';
 import Tabs from '@theme/Tabs';
+import DataDictionaryCard from '../../../snippets/assets/data-dictionary-card.md';
 import TabItem from '@theme/TabItem';
 
 # Message Service
@@ -134,13 +135,7 @@ When calling a Message Service function from a processor, the following paramete
 
 ### Data Dictionary
 
-The Data Dictionary editor allows you to define custom data types for use as request and response types in your functions.
-
-The namespace for these types is determined by the **Data Dictionary Namespace** setting. If not specified, it defaults to `Service{Name}Types`.
-
-:::tip
-Use the Data Dictionary to define the structure of your message payloads. For example, define an `OrderConfirmation` type with fields like `orderId`, `customerId`, and `timestamp`, then assign it as the `Request type` of a `PublishOrderConfirmation` function.
-:::
+<DataDictionaryCard />
 
 ## Using the Message Service from a Script Processor
 

--- a/docs/03-assets/01-workflow-assets/services/asset-service-message.md
+++ b/docs/03-assets/01-workflow-assets/services/asset-service-message.md
@@ -133,8 +133,6 @@ When calling a Message Service function from a processor, the following paramete
 | `Request` | The message payload, matching the `Request type` defined above |
 | `Source` | Optional. The name of the Message Source to publish to. Required if the service references more than one Message Source |
 
-### Data Dictionary
-
 <DataDictionaryCard />
 
 ## Using the Message Service from a Script Processor

--- a/docs/snippets/assets/data-dictionary-card.md
+++ b/docs/snippets/assets/data-dictionary-card.md
@@ -1,10 +1,10 @@
-## Data Dictionary {#data-dictionary-editor}
+### Data Dictionary {#data-dictionary-editor}
 
 The Data Dictionary allows you to define complex data structures which can be mapped onto external data types and vice versa. This is necessary whenever an asset needs to exchange structured data with an external system — for example, when reading from or writing to a database, an HTTP API, a message queue, or any other format that carries typed fields.
 
 Rather than hard-coding external field names and types into your Workflow, you define your own internal data types here. These internal types are then mapped to the external system's fields at the asset level. This means your Workflow scripts work with consistent, self-documenting data structures regardless of which external system the data came from.
 
-### When you need it
+#### When you need it
 
 Whenever you configure an asset that exchanges structured data — a JDBC Service, a DynamoDB Service, an HTTP endpoint, an MQ message, a database Resource — you use the Data Dictionary to declare the types that represent:
 
@@ -12,7 +12,7 @@ Whenever you configure an asset that exchanges structured data — a JDBC Servic
 - **Result data** — the data the external system returns to your Workflow
 - **Intermediate structures** — types that hold data during a transformation
 
-### Entity Types
+#### Entity Types
 
 The Data Dictionary is organized as a tree of typed entities. The available entity types are:
 
@@ -24,17 +24,17 @@ The Data Dictionary is organized as a tree of typed entities. The available enti
 | **Choice** | A type that holds exactly one of several possible member types. |
 | **Array** | A sequence of elements of a single contained type. |
 
-### Defining Types — Step by Step
+#### Defining Types — Step by Step
 
 The following walkthrough shows how to build a data structure using the Data Dictionary editor. The example assumes a SQL `customer` table with columns `id`, `name`, and `address` — but the same pattern applies whenever you need to declare types for any asset.
 
-#### 1. Declare a new type
+##### 1. Declare a new type
 
 Click **Declare Root Type** in the toolbar to add a top-level entity.
 
 ![Declare root type](./.asset-data-dictionary-card_images/0cd537d7.png "Declare root type ")
 
-#### 2. Declare a namespace (optional)
+##### 2. Declare a namespace (optional)
 
 Namespaces organize related types. To add one, right-click an existing node and select **Add Sibling**, then set the element type to `Namespace`.
 
@@ -46,7 +46,7 @@ Namespaces organize related types. To add one, right-click an existing node and 
 
 * **`Description`** — Optional free-text description.
 
-#### 3. Declare a Sequence under the namespace
+##### 3. Declare a Sequence under the namespace
 
 Right-click the namespace and choose **Add Child** to add a child element.
 
@@ -62,7 +62,7 @@ Click the arrow next to the namespace name and select `Add child`. Then fill in 
 
 * **`Extendable Sequence`** — When checked, layline.io can dynamically extend the sequence's member list if incoming data contains fields that are not explicitly defined. Leave unchecked if all fields are known in advance.
 
-#### 4. Add members to the Sequence
+##### 4. Add members to the Sequence
 
 With the Sequence selected, click **Add Child** to add individual fields:
 
@@ -70,7 +70,7 @@ With the Sequence selected, click **Add Child** to add individual fields:
 
 Each member maps to a column in the external data source. You can reference any member by its full path — for example, `MyNamespace.Customer.Name` — from your Workflow scripts.
 
-### Common Entity Fields
+#### Common Entity Fields
 
 These fields are available on all entity types:
 
@@ -83,7 +83,7 @@ These fields are available on all entity types:
 | **Members** | (Sequence) Ordered list of typed fields — click **Add Child** to add each one |
 | **Elements** | (Enumeration) Named integer constants making up the enumeration |
 
-### Advanced Features
+#### Advanced Features
 
 **Inheritance and Override**  
 Entities inherited from a parent format or resource appear in the tree in a distinct inherited style. These are read-only unless overridden. Click **Reset to Parent** on an overridden entity to restore the inherited definition.
@@ -94,7 +94,7 @@ Use the toolbar buttons to copy a complete entity subtree and paste it elsewhere
 **Filter and Sort**  
 Use the **Filter** field to search entities by name. The sort buttons order nodes ascending or descending alphabetically.
 
-### See Also
+#### See Also
 
 - [Data Dictionary Format Asset](/docs/formats/asset-format-data-dictionary) — standalone Data Dictionary asset
 - [DynamoDB Service](/docs/assets/01-workflow-assets/services/asset-service-dynamo-db) — Data Dictionary in context of a DynamoDB Service


### PR DESCRIPTION
## Summary

All asset docs for components using `DataDictionaryCard.vue` in `layline-spa` now use the shared `data-dictionary-card.md` snippet instead of bespoke explanations.

## Changed files (8)

| File | Change |
|------|--------|
| `asset-service-aerospike.md` | Replace bespoke Data Dictionary section with snippet |
| `asset-service-cassandra.md` | Replace bespoke Data Dictionary section with snippet |
| `asset-service-hazelcast.md` | Replace bespoke Data Dictionary section with snippet |
| `asset-service-http.md` | Replace bespoke Data Dictionary section with snippet |
| `asset-service-jdbc.md` | Replace bespoke Data Dictionary section with snippet |
| `asset-service-dynamo-db.md` | Replace bespoke Data Dictionary section with snippet |
| `asset-service-message.md` | Replace bespoke Data Dictionary section with snippet |
| `asset-resource-data-dictionary-updates.md` | Replace bespoke Format Types section with snippet |

## Assets NOT changed (correctly)
- `FormatDataDictionaryEditor.vue` → `03-asset-format-data-dictionary.md` — this IS the Data Dictionary reference doc; using the snippet here would be circular
- `HttpFormat` → `03-asset-format-http.md` — uses a custom HTTP path-based dictionary UI, not the generic DataDictionaryCard component

Fixes LAY-30.