### PR TITLE
Doc: Rename docs version from 2.0.0 to 2.x (LAY-71)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,7 +50,7 @@ const config = {
                     versions: {
                         current: {
                             label: '2.x',
-                            // path: '2.0.0', // Do not add a path for the current version, it is the default. --> Helps with SEO.
+                            // path: '2.x', // Do not add a path for the current version, it is the default. --> Helps with SEO.
                         }
                     },
                     exclude: [


### PR DESCRIPTION
## Summary

Closes LAY-71.

The Docusaurus config already had `label: '2.x'` set correctly. This PR removes the one remaining stale `2.0.0` reference — a commented-out `path` value in `docusaurus.config.js`.

## Changes
- `docusaurus.config.js`: Updated commented-out `path: '2.0.0'` → `path: '2.x'` for consistency

## Verification
- No `2.0.0` strings remain in any live docs source (audit/ files are historical, package-lock.json is npm deps — both intentionally untouched)
- `npm run build` passes with zero errors (2 pre-existing broken link warnings, not introduced here)