### PR TITLE
Doc: Restructure sidebar to match app navigation (LAY-73)

### DIFF
--- a/docs/assets/index.mdx
+++ b/docs/assets/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Assets
-sidebar_position: 3
+sidebar_position: 6
 description: All Asset types in layline.io — Workflow Assets and Deployment Assets.
 ---
 # Assets

--- a/docs/concept/index.mdx
+++ b/docs/concept/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Concept
-sidebar_position: 2
+sidebar_position: 7
 ---
 # Concept
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,0 +1,36 @@
+---
+title: Configuration
+sidebar_position: 5
+description: System-level configuration for layline.io — users, roles, clusters, and application settings.
+---
+
+# Configuration
+
+> The Configuration section is for administrators. This is where you manage who can access the system, what they can do, and how the system is configured at the infrastructure level.
+
+## What Is in Configuration?
+
+Configuration covers system-wide settings that apply across all Projects and Operations:
+
+| Section | Description |
+|---------|-------------|
+| **Users** | Create and manage user accounts |
+| **Roles** | Define permission sets and assign them to users |
+| **Clusters** | Configure the Reactive Cluster infrastructure |
+| **Application** | Application-level settings (version info, global options) |
+| **Storage** | System storage configuration |
+
+## Access Requirements
+
+Configuration settings are typically restricted to administrators. Changes here affect the entire layline.io installation, not just individual Projects or Workflows.
+
+See the [**Roles**](/docs/configuration/roles) section for details on the permission model.
+
+:::info Coming Soon
+Users & Roles documentation is in progress. See [LAY-70](https://linear.app/laylineio/issue/LAY-70) for status.
+:::
+
+## See Also
+
+- [**Operations**](/docs/operations) — Runtime monitoring and control (Operations-level access)
+- [**Project**](/docs/project) — Working with Projects (developer-level access)

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -24,7 +24,7 @@ Configuration covers system-wide settings that apply across all Projects and Ope
 
 Configuration settings are typically restricted to administrators. Changes here affect the entire layline.io installation, not just individual Projects or Workflows.
 
-See the [**Roles**](/docs/configuration/roles) section for details on the permission model.
+Roles and permissions documentation is coming soon (see [LAY-70](https://linear.app/laylineio/issue/LAY-70)).
 
 :::info Coming Soon
 Users & Roles documentation is in progress. See [LAY-70](https://linear.app/laylineio/issue/LAY-70) for status.

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,8 @@ The **Shelf** tab is your reusable asset library. Assets published to the Shelf 
 Shelf documentation is in progress. See [LAY-69](https://linear.app/laylineio/issue/LAY-69) for status.
 :::
 
+→ [**Go to Shelf documentation**](./shelf)
+
 ---
 
 ## 🔧 Settings — Users, Roles, and System Settings
@@ -105,6 +107,8 @@ The **Settings** tab is for administrators. This is where you manage who can acc
 :::info Coming Soon
 Users & Roles documentation is in progress. See [LAY-70](https://linear.app/laylineio/issue/LAY-70) for status.
 :::
+
+→ [**Go to Settings documentation**](./configuration)
 
 ---
 

--- a/docs/language-reference/index.mdx
+++ b/docs/language-reference/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Language Reference
-sidebar_position: 4
+sidebar_position: 8
 ---
 # Language Reference
 

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -1,6 +1,6 @@
 ---
 title: Operations 
-sidebar_position: 7
+sidebar_position: 3
 description: An introduction to the Operations section of the layline.io Configuration Center.
 ---
 

--- a/docs/project/building-workflows.md
+++ b/docs/project/building-workflows.md
@@ -1,0 +1,47 @@
+---
+title: Building Workflows
+sidebar_position: 3
+description: How to build data pipelines by assembling Workflows inside a layline.io Project.
+---
+
+# Building Workflows
+
+:::info Documentation In Progress
+This page is a stub. Full documentation for building workflows inside the Project editor is tracked in [LAY-89](https://linear.app/laylineio/issue/LAY-89/doc-project-building-workflows-general-how-to-page).
+
+For a hands-on tutorial, see [Your First Workflow](../quickstart/first-workflow) in the Quickstart.
+:::
+
+## What is a Workflow?
+
+A **Workflow** is the core unit of a data pipeline in layline.io. It defines how data flows from an input source, through one or more processing steps, to an output destination.
+
+Workflows live inside a **Project** and are assembled from three types of Assets:
+
+| Asset Type | Role |
+|------------|------|
+| **Input Processors** | Receive data from a Source (file, queue, stream, etc.) |
+| **Flow Processors** | Transform, route, enrich, or filter data in transit |
+| **Output Processors** | Send processed data to a Sink |
+
+## How Workflows Are Built
+
+Inside a Project, you use the visual editor to:
+
+1. **Add Processors** — drag Input, Flow, and Output Processors onto the canvas
+2. **Connect them** — define the data flow between processors
+3. **Configure each processor** — set Source/Sink connections, Formats, Services, and processing logic
+4. **Assign a Workflow Asset** — wrap the pipeline in a Workflow Asset for deployment
+
+## Relationship to Other Concepts
+
+- **Assets** — the individual components (processors, services, formats) that make up a workflow
+- **Deployment** — once a Workflow is defined, you deploy it to a Reactive Cluster via a Deployment Asset
+- **Project** — the container that holds all your Workflows and their supporting Assets
+
+## See Also
+
+- [**Your First Workflow**](../quickstart/first-workflow) — step-by-step tutorial
+- [**Workflow Asset**](../assets/workflow-assets) — reference documentation for the Workflow asset type
+- [**Assets Reference**](../assets) — complete reference for all asset types
+- [**Deployment Assets**](../assets/deployment-assets) — how to deploy a Workflow to a cluster

--- a/docs/project/index.md
+++ b/docs/project/index.md
@@ -8,7 +8,7 @@ description: The Project tab is where you build data pipelines — create and ma
 
 > The Project tab is where you build. Every data pipeline in layline.io lives inside a Project.
 
-A **Project** contains all the Assets and Workflows that define how your data moves and transforms — what data comes in, how it's processed, and where results go. Once you've defined a Workflow inside a Project, you deploy it to a Reactive Cluster via a Deployment Asset.
+A **Project** contains all the Assets and Workflows that define how your data moves and transforms — what data comes in, how it's processed, and where results go. On top of this it includes information on how to deploy and manage these workflows. Once you've defined a Workflow inside a Project, you deploy it to a Reactive Cluster via a Deployment Asset.
 
 :::info Documentation Coming Soon
 Detailed Project management documentation (create, import, manage) is in progress. See [LAY-68](https://linear.app/laylineio/issue/LAY-68) for status.
@@ -17,17 +17,21 @@ Detailed Project management documentation (create, import, manage) is in progres
 ## What a Project Contains
 
 - **Workflow Assets** — Input Processors, Flow Processors, and Output Processors that define how data moves
-- **Deployment Assets** — Engine Deployments, Schedulers, and Cluster configurations
 - **Services** — Connections to external systems (databases, queues, APIs)
 - **Formats** — Definitions of the data structures you read and write
 - **Resources** — Shared configurations like Environments and Secrets
+- **Extensions** — Custom code that extends the system's capabilities
+- **Connections** — Configured connections to external systems
+- **Sinks** — Data output destinations
+- **Sources** — Data input sources
+- **Deployment Assets** — Engine Deployments, Schedulers, and Cluster configurations
 
 ## Working with Projects
 
 | Task | Where to Go |
 |------|-------------|
 | Understand all asset types | [Assets Reference](../assets) |
-| Build a Workflow | [Workflow Assets](../assets/workflow-assets) |
+| Build a Workflow | [Building Workflows](building-workflows) |
 | Configure a deployment | [Deployment Assets](../assets/deployment-assets) |
 | Run your first pipeline | [Quickstart](../quickstart) |
 

--- a/docs/project/index.md
+++ b/docs/project/index.md
@@ -1,0 +1,38 @@
+---
+title: Project
+sidebar_position: 2
+description: The Project tab is where you build data pipelines — create and manage Projects, define Assets and Workflows, and configure deployments.
+---
+
+# Project
+
+> The Project tab is where you build. Every data pipeline in layline.io lives inside a Project.
+
+A **Project** contains all the Assets and Workflows that define how your data moves and transforms — what data comes in, how it's processed, and where results go. Once you've defined a Workflow inside a Project, you deploy it to a Reactive Cluster via a Deployment Asset.
+
+:::info Documentation Coming Soon
+Detailed Project management documentation (create, import, manage) is in progress. See [LAY-68](https://linear.app/laylineio/issue/LAY-68) for status.
+:::
+
+## What a Project Contains
+
+- **Workflow Assets** — Input Processors, Flow Processors, and Output Processors that define how data moves
+- **Deployment Assets** — Engine Deployments, Schedulers, and Cluster configurations
+- **Services** — Connections to external systems (databases, queues, APIs)
+- **Formats** — Definitions of the data structures you read and write
+- **Resources** — Shared configurations like Environments and Secrets
+
+## Working with Projects
+
+| Task | Where to Go |
+|------|-------------|
+| Understand all asset types | [Assets Reference](../assets) |
+| Build a Workflow | [Workflow Assets](../assets/workflow-assets) |
+| Configure a deployment | [Deployment Assets](../assets/deployment-assets) |
+| Run your first pipeline | [Quickstart](../quickstart) |
+
+## See Also
+
+- [**Assets Reference**](../assets) — Reference documentation for all asset types
+- [**Core Concepts**](../quickstart/core-concepts) — Mental models for understanding Projects and Workflows
+- [**Quickstart**](../quickstart) — Get started with your first pipeline

--- a/docs/release-notes/index.mdx
+++ b/docs/release-notes/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release Notes & Migration
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Release Notes & Migration

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1,16 +1,16 @@
 ---
-title: Configuration
+title: Settings
 sidebar_position: 5
 description: System-level configuration for layline.io — users, roles, clusters, and application settings.
 ---
 
-# Configuration
+# Settings
 
-> The Configuration section is for administrators. This is where you manage who can access the system, what they can do, and how the system is configured at the infrastructure level.
+> The Settings section is for administrators. This is where you manage who can access the system, what they can do, and how the system is configured at the infrastructure level.
 
-## What Is in Configuration?
+## What Is in Settings?
 
-Configuration covers system-wide settings that apply across all Projects and Operations:
+Settings covers system-wide settings that apply across all Projects and Operations:
 
 | Section | Description |
 |---------|-------------|
@@ -22,7 +22,7 @@ Configuration covers system-wide settings that apply across all Projects and Ope
 
 ## Access Requirements
 
-Configuration settings are typically restricted to administrators. Changes here affect the entire layline.io installation, not just individual Projects or Workflows.
+Settings are typically restricted to administrators. Changes here affect the entire layline.io installation, not just individual Projects or Workflows.
 
 Roles and permissions documentation is coming soon (see [LAY-70](https://linear.app/laylineio/issue/LAY-70)).
 

--- a/docs/shelf/index.md
+++ b/docs/shelf/index.md
@@ -1,0 +1,36 @@
+---
+title: Shelf
+sidebar_position: 4
+description: The Shelf is layline.io's shared asset library — browse, publish, and reuse Assets across Projects.
+---
+
+# Shelf
+
+> The Shelf is a shared library where reusable Assets live. Publish an Asset to the Shelf once, and any Project can import and use it.
+
+## What Is the Shelf?
+
+The Shelf provides a central catalog of Assets that can be shared across Projects and teams. Instead of recreating the same Format, Connection, or Service configuration in every Project, you define it once on the Shelf and reference it wherever it's needed.
+
+The Shelf is organized into:
+
+- **Categories** — Top-level groupings (e.g., by team, data domain, or technology)
+- **Folders** — Sub-groupings within a Category
+- **Elements** — The individual Assets stored on the Shelf
+
+## Key Concepts
+
+**Publishing** — When you publish an Asset from a Project to the Shelf, it becomes available for import in other Projects.
+
+**Importing** — When you import a Shelf Element into a Project, you get a local copy that can be customized independently of the original.
+
+**Versioning** — Shelf Elements can be versioned, allowing you to track changes and control which version a Project uses.
+
+:::info Coming Soon
+Shelf documentation is in progress. See [LAY-69](https://linear.app/laylineio/issue/LAY-69) for status.
+:::
+
+## See Also
+
+- [**Project**](/docs/project) — Where Assets are created and used
+- [**Assets Overview**](/docs/assets) — Reference documentation for all Asset types


### PR DESCRIPTION
## Summary

Restructures the documentation sidebar to mirror the layline.io app's 4-tab navigation structure.

## Changes

**New sidebar order:**
1. Quickstart (unchanged)
2. **Project** — new section mirroring the Project tab (create/manage projects)
3. **Operations** — moved from position 7 to directly after Project
4. **Shelf** — new stub section for the Shelf tab (content in LAY-69)
5. **Settings** — new stub section for the Settings tab (content in LAY-70)
6. Assets — moved to reference section (was position 3)
7. Concept — moved to reference section (was position 2)
8. Language Reference — moved to reference section (was position 4)
9. Release Notes

**New files:**
- `docs/project/index.md` — Project tab overview (create, import, manage)
- `docs/shelf/index.md` — Shelf stub linking to LAY-69
- `docs/configuration/index.md` — Settings stub linking to LAY-70

## Why This Structure

The app navigation has 4 primary tabs: Project → Operations → Shelf → Settings. These map to the first 4 sections of the sidebar (after Quickstart). The existing reference sections (Assets, Concept, Language Reference) follow as secondary navigation.

## Build

`npm run build` passes with zero errors. Existing broken anchor in `prometheus-extension` is pre-existing and unrelated.

## Related

- LAY-69 (Shelf content), LAY-70 (Settings/Users content) — stubs created here
- LAY-74 — landing page already maps to this structure