### PR TITLE
Fix: Correct broken links in workflow-assets documentation

### DIFF
--- a/docs/assets/workflow-assets/connections/asset-connection-aws.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-aws.md
@@ -116,20 +116,20 @@ This requires the provision of an Access Key and a Secret as described below.
 ![82f074a4.png](.asset-connection-aws_images/82f074a4.png "Access Key and Secret - manual entry (Connection AWS)")
 
 * **`Access Key`**: Enter the Access Key you want to use to access the endpoint.
-  You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+  You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 
 ![6db64fab.png](.asset-connection-aws_images/6db64fab.png "Access Key as placeholder")
 
 * **`Use Secret`**: Check this box, if you have a configured a secret and want to reference this here
   instead of entering the Secret directly.
-  Pick one of the Secrets in the list. The Secret must have been defined in a [Secrets Resource](../resources/asset-resource-secret).
+  Pick one of the Secrets in the list. The Secret must have been defined in a [Secrets Resource](/docs/assets/workflow-assets/resources/asset-resource-secret).
   You cannot manually enter a secret here.
 
 ![79a368d8.png](.asset-connection-aws_images/79a368d8.png "Use Secret (Connection AWS)")
 
 * **`Use alternative provider`**:
   Check this box, if you do not want to connect to Amazon AWS, but an alternative, compatible provider with a different URL.
-  You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+  You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 
 ![3154d354.png](.asset-connection-aws_images/3154d354.png "Use alternative provider (Connection AWS)")
 
@@ -167,7 +167,7 @@ The Reactive Engine must be able to reach the configured endpoint, or otherwise 
 
 * [S3 Source](/docs/assets/workflow-assets/sources/asset-source-s3.md)
 * [S3 Sink](/docs/assets/workflow-assets/sinks/asset-sink-s3)
-* [Create and manage secrets](../resources/asset-resource-secret)
+* [Create and manage secrets](/docs/assets/workflow-assets/resources/asset-resource-secret)
 
 ### External
 

--- a/docs/assets/workflow-assets/connections/asset-connection-aws.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-aws.md
@@ -22,13 +22,13 @@ To enable the connection to AWS cloud services or an AWS compatible endpoint.
 
 | Asset type | Link                                                          |
 |------------|---------------------------------------------------------------|
-| Source     | [S3 Source](../sources/asset-source-s3.md)             |
-|            | [SQS Source](../sources/asset-source-sqs.md)           |
-| Sink       | [S3 Sink](../sinks/asset-sink-s3)                   |
-|            | [SNS Sink](../sinks/asset-sink-sns)                 |
-|            | [SQS Sink](../sinks/asset-sink-sqs)                 |
-|            | [Kinesis Sink](../sinks/asset-sink-kinesis)         |
-|            | [EventBridge Sink](../sinks/asset-sink-eventbridge) |
+| Source     | [S3 Source](/docs/assets/workflow-assets/sources/asset-source-s3.md)             |
+|            | [SQS Source](/docs/assets/workflow-assets/sources/asset-source-sqs.md)           |
+| Sink       | [S3 Sink](/docs/assets/workflow-assets/sinks/asset-sink-s3)                   |
+|            | [SNS Sink](/docs/assets/workflow-assets/sinks/asset-sink-sns)                 |
+|            | [SQS Sink](/docs/assets/workflow-assets/sinks/asset-sink-sqs)                 |
+|            | [Kinesis Sink](/docs/assets/workflow-assets/sinks/asset-sink-kinesis)         |
+|            | [EventBridge Sink](/docs/assets/workflow-assets/sinks/asset-sink-eventbridge) |
       
 
 ## Configuration
@@ -165,8 +165,8 @@ The Reactive Engine must be able to reach the configured endpoint, or otherwise 
 
 ### Internal
 
-* [S3 Source](../sources/asset-source-s3.md)
-* [S3 Sink](../sinks/asset-sink-s3)
+* [S3 Source](/docs/assets/workflow-assets/sources/asset-source-s3.md)
+* [S3 Sink](/docs/assets/workflow-assets/sinks/asset-sink-s3)
 * [Create and manage secrets](../resources/asset-resource-secret)
 
 ### External

--- a/docs/assets/workflow-assets/connections/asset-connection-email.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-email.md
@@ -23,7 +23,7 @@ Defines the connection parameters for an Email endpoint.
 
 | Asset type | Link                                             |
 |------------|--------------------------------------------------|
-| Source     | [Email Source](../sources/asset-source-email.md)    |
+| Source     | [Email Source](/docs/assets/workflow-assets/sources/asset-source-email.md)    |
 | Service    | [Email Service](../services/asset-service-email) |
 
 ## Configuration

--- a/docs/assets/workflow-assets/connections/asset-connection-email.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-email.md
@@ -24,7 +24,7 @@ Defines the connection parameters for an Email endpoint.
 | Asset type | Link                                             |
 |------------|--------------------------------------------------|
 | Source     | [Email Source](/docs/assets/workflow-assets/sources/asset-source-email.md)    |
-| Service    | [Email Service](../services/asset-service-email) |
+| Service    | [Email Service](/docs/assets/workflow-assets/services/asset-service-email) |
 
 ## Configuration
 
@@ -172,7 +172,7 @@ For settings please see [Microsoft Client Credential Flow](#microsoft-oauth-clie
 ---
 
 :::tip Fields marked with "**_macro supported_**"
-You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 :::
 
 ---

--- a/docs/assets/workflow-assets/connections/asset-connection-ftp.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-ftp.md
@@ -22,8 +22,8 @@ Defines the connection parameters for an FTP/SFTP endpoint.
 
 | Asset type | Link                                                |
 |------------|-----------------------------------------------------|
-| Source     | [FTP Source](../sources/asset-source-ftp.md) |
-| Sink       | [FTP Sink](../sinks/asset-sink-ftp)       |
+| Source     | [FTP Source](/docs/assets/workflow-assets/sources/asset-source-ftp.md) |
+| Sink       | [FTP Sink](/docs/assets/workflow-assets/sinks/asset-sink-ftp)       |
 
 ## Configuration
 
@@ -113,8 +113,8 @@ The Reactive Engine must be able to reach the configured endpoint, or otherwise 
 
 ### Internal
 
-* [FTP Source](../sources/asset-source-ftp.md)
-* [FTP Sink](../sinks/asset-sink-ftp)
+* [FTP Source](/docs/assets/workflow-assets/sources/asset-source-ftp.md)
+* [FTP Sink](/docs/assets/workflow-assets/sinks/asset-sink-ftp)
 * [Stream Input Processor](../processors-input/asset-input-stream)
 * [Stream Output Processor](../processors-output/asset-output-stream)
 * [Create and manage secrets](../resources/asset-resource-secret)

--- a/docs/assets/workflow-assets/connections/asset-connection-ftp.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-ftp.md
@@ -78,7 +78,7 @@ For FTP/SFTP, layline.io supports a number of different authentication methods:
   If - for example - your password is `pass_${env:MYVAR}_word` and you do not want the term `${env:MYVAR}` to be interpreted as a macro and then replaced with the MYVAR environment variable, then tick
   this box to keep the raw string value.
 
-* **`User/Secret`** : Enter a `Username` and select a `Secret` from the drop-down list. If the list is empty, then you need to first [create a secret](../resources/asset-resource-secret) to
+* **`User/Secret`** : Enter a `Username` and select a `Secret` from the drop-down list. If the list is empty, then you need to first [create a secret](/docs/assets/workflow-assets/resources/asset-resource-secret) to
   be
   able to assign it here.
 
@@ -115,9 +115,9 @@ The Reactive Engine must be able to reach the configured endpoint, or otherwise 
 
 * [FTP Source](/docs/assets/workflow-assets/sources/asset-source-ftp.md)
 * [FTP Sink](/docs/assets/workflow-assets/sinks/asset-sink-ftp)
-* [Stream Input Processor](../processors-input/asset-input-stream)
-* [Stream Output Processor](../processors-output/asset-output-stream)
-* [Create and manage secrets](../resources/asset-resource-secret)
+* [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream)
+* [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream)
+* [Create and manage secrets](/docs/assets/workflow-assets/resources/asset-resource-secret)
 
 ---
 <WipDisclaimer></WipDisclaimer>

--- a/docs/assets/workflow-assets/connections/asset-connection-google-cloud.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-google-cloud.md
@@ -89,8 +89,8 @@ All Google Cloud Settings fields can be overridden in child assets or inherited 
 
 ## See Also
 
-- [**GCS Sink**](../sinks/asset-sink-gcs) — Write objects to Google Cloud Storage
-- [**GCS Source**](../sources/asset-source-google-cloud-storage.md) — Read objects from Google Cloud Storage
+- [**GCS Sink**](/docs/assets/workflow-assets/sinks/asset-sink-gcs) — Write objects to Google Cloud Storage
+- [**GCS Source**](/docs/assets/workflow-assets/sources/asset-source-google-cloud-storage.md) — Read objects from Google Cloud Storage
 
 ---
 <WipDisclaimer></WipDisclaimer>

--- a/docs/assets/workflow-assets/connections/asset-connection-google-cloud.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-google-cloud.md
@@ -66,7 +66,7 @@ If no OAuth Client resource exists in the project, you must create one first. Th
 407603625325-45ik7ma1elfme3qidga7jstkbfnfmhdu.apps.googleusercontent.com
 ```
 
-To use your own OAuth client (recommended for production), replace this with your client's client ID. You can also use a placeholder referencing an [Environment Resource](../resources/asset-resource-environment):
+To use your own OAuth client (recommended for production), replace this with your client's client ID. You can also use a placeholder referencing an [Environment Resource](/docs/assets/workflow-assets/resources/asset-resource-environment):
 
 ```
 ${GOOGLE_CLIENT_ID}

--- a/docs/assets/workflow-assets/connections/asset-connection-kafka.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-kafka.md
@@ -18,8 +18,8 @@ Defines the connection parameters for a Kafka endpoint.
 
 | Asset type | Link                                                    |
 |------------|---------------------------------------------------------|
-| Source     | [Kafka Source](../sources/asset-source-kafka.md) |
-| Sink       | [Kafka Sink](../sinks/asset-sink-kafka)       |
+| Source     | [Kafka Source](/docs/assets/workflow-assets/sources/asset-source-kafka.md) |
+| Sink       | [Kafka Sink](/docs/assets/workflow-assets/sinks/asset-sink-kafka)       |
 
 ## Configuration
 
@@ -146,8 +146,8 @@ The Reactive Engine must be able to reach the configured endpoint, or otherwise 
 
 ### Internal
 
-* [Kafka Source](../sources/asset-source-kafka.md)
-* [Kafka Sink](../sinks/asset-sink-kafka)
+* [Kafka Source](/docs/assets/workflow-assets/sources/asset-source-kafka.md)
+* [Kafka Sink](/docs/assets/workflow-assets/sinks/asset-sink-kafka)
 * [Kafka Input Processor](../processors-input/asset-input-kafka)
 * [Frame Output Processor](../processors-output/asset-output-frame)
 * [Create and manage secrets](../resources/asset-resource-secret)

--- a/docs/assets/workflow-assets/connections/asset-connection-kafka.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-kafka.md
@@ -62,7 +62,7 @@ If SSL is enabled, and you have either a truststore and optionally a keystore, t
   This entry is equivalent to the `ssl.truststore.location` property.
   Example: `/var/private/ssl/kafka.server.truststore.jks`
 
-* **`Use identitity certificate`**: Select the secret necessary to decrypt the truststore. If this list is empty, then you first need to create it [here](../resources/asset-resource-secret).
+* **`Use identitity certificate`**: Select the secret necessary to decrypt the truststore. If this list is empty, then you first need to create it [here](/docs/assets/workflow-assets/resources/asset-resource-secret).
   This entry is equivalent to the `ssl.truststore.password` property.
   Example: `1234`
 
@@ -70,11 +70,11 @@ If SSL is enabled, and you have either a truststore and optionally a keystore, t
   This entry is equivalent to the `ssl.keystore.location` property.
   Example: `/var/private/ssl/kafka.server.keystore.jks`
 
-* **`Keystore password secret`**: Select the secret necessary to decrypt the keystore. If this list is empty, then you first need to create it [here](../resources/asset-resource-secret).
+* **`Keystore password secret`**: Select the secret necessary to decrypt the keystore. If this list is empty, then you first need to create it [here](/docs/assets/workflow-assets/resources/asset-resource-secret).
   This entry is equivalent to the `ssl.keystore.password` property.
   Example: `test1234`
 
-* **`Key password secret`**:  Password secret for decryption of Key in Keystore. If this list is empty, then you first need to create it [here](../resources/asset-resource-secret).
+* **`Key password secret`**:  Password secret for decryption of Key in Keystore. If this list is empty, then you first need to create it [here](/docs/assets/workflow-assets/resources/asset-resource-secret).
   This entry is equivalent to the `ssl.key.password` property.
   Example: `test1234`
 
@@ -115,7 +115,7 @@ For _SASL / PLAIN_ and _SCRAM_ based authentication you need to consider the fol
   this box to keep the raw string value.
 
 * **`User/Secret`**:
-  Enter a `Username` and select a `Secret` from the drop-down list. It the list is empty, then you need to first [create a secret](../resources/asset-resource-secret) to be able to assign it
+  Enter a `Username` and select a `Secret` from the drop-down list. It the list is empty, then you need to first [create a secret](/docs/assets/workflow-assets/resources/asset-resource-secret) to be able to assign it
   here.
 
   Please [follow this link to "Advanced Concepts"](../../../concept/advanced/secret-management.md) to learn about the concept and use of the Security Storage.
@@ -148,9 +148,9 @@ The Reactive Engine must be able to reach the configured endpoint, or otherwise 
 
 * [Kafka Source](/docs/assets/workflow-assets/sources/asset-source-kafka.md)
 * [Kafka Sink](/docs/assets/workflow-assets/sinks/asset-sink-kafka)
-* [Kafka Input Processor](../processors-input/asset-input-kafka)
-* [Frame Output Processor](../processors-output/asset-output-frame)
-* [Create and manage secrets](../resources/asset-resource-secret)
+* [Kafka Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-kafka)
+* [Frame Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-frame)
+* [Create and manage secrets](/docs/assets/workflow-assets/resources/asset-resource-secret)
 
 ### External
 

--- a/docs/assets/workflow-assets/connections/asset-connection-msgraph.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-msgraph.md
@@ -22,10 +22,10 @@ Defines the connection parameters for various Microsoft application endpoints, f
 
 | Asset type | Link                                                    |
 |------------|---------------------------------------------------------|
-| Source     | [OneDrive Source](../sources/asset-source-onedrive.md)     |
-|            | [SharePoint Source](../sources/asset-source-sharepoint.md) |
-| Sink       | [OneDrive Sink](../sinks/asset-sink-onedrive)           |
-|            | [SharePoint Sink](../sinks/asset-sink-sharepoint)       |
+| Source     | [OneDrive Source](/docs/assets/workflow-assets/sources/asset-source-onedrive.md)     |
+|            | [SharePoint Source](/docs/assets/workflow-assets/sources/asset-source-sharepoint.md) |
+| Sink       | [OneDrive Sink](/docs/assets/workflow-assets/sinks/asset-sink-onedrive)           |
+|            | [SharePoint Sink](/docs/assets/workflow-assets/sinks/asset-sink-sharepoint)       |
 | Service    | [Teams Service](../services/asset-service-teams)        |
 
 ## Configuration

--- a/docs/assets/workflow-assets/connections/asset-connection-msgraph.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-msgraph.md
@@ -26,7 +26,7 @@ Defines the connection parameters for various Microsoft application endpoints, f
 |            | [SharePoint Source](/docs/assets/workflow-assets/sources/asset-source-sharepoint.md) |
 | Sink       | [OneDrive Sink](/docs/assets/workflow-assets/sinks/asset-sink-onedrive)           |
 |            | [SharePoint Sink](/docs/assets/workflow-assets/sinks/asset-sink-sharepoint)       |
-| Service    | [Teams Service](../services/asset-service-teams)        |
+| Service    | [Teams Service](/docs/assets/workflow-assets/services/asset-service-teams)        |
 
 ## Configuration
 

--- a/docs/assets/workflow-assets/connections/asset-connection-nfs.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-nfs.md
@@ -72,8 +72,8 @@ Defines the connection parameters for an NFS (Network File System) endpoint.
 
 * [NFS Source](/docs/assets/workflow-assets/sources/asset-source-nfs.md)
 * [NFS Sink](/docs/assets/workflow-assets/sinks/asset-sink-nfs)
-* [Stream Input Processor](../processors-input/asset-input-stream)
-* [Stream Output Processor](../processors-output/asset-output-stream)
+* [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream)
+* [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream)
 
 ---
 <WipDisclaimer></WipDisclaimer>

--- a/docs/assets/workflow-assets/connections/asset-connection-nfs.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-nfs.md
@@ -22,8 +22,8 @@ Defines the connection parameters for an NFS (Network File System) endpoint.
 
 | Asset type | Link                                                |
 |------------|-----------------------------------------------------|
-| Source     | [NFS Source](../sources/asset-source-nfs.md) |
-| Sink       | [NFS Sink](../sinks/asset-sink-nfs)       |
+| Source     | [NFS Source](/docs/assets/workflow-assets/sources/asset-source-nfs.md) |
+| Sink       | [NFS Sink](/docs/assets/workflow-assets/sinks/asset-sink-nfs)       |
 
 ## Configuration
 
@@ -70,8 +70,8 @@ Defines the connection parameters for an NFS (Network File System) endpoint.
 
 ### Internal
 
-* [NFS Source](../sources/asset-source-nfs.md)
-* [NFS Sink](../sinks/asset-sink-nfs)
+* [NFS Source](/docs/assets/workflow-assets/sources/asset-source-nfs.md)
+* [NFS Sink](/docs/assets/workflow-assets/sinks/asset-sink-nfs)
 * [Stream Input Processor](../processors-input/asset-input-stream)
 * [Stream Output Processor](../processors-output/asset-output-stream)
 

--- a/docs/assets/workflow-assets/connections/asset-connection-smb.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-smb.md
@@ -84,7 +84,7 @@ You have two options to authenticate against the SMB endpoint:
   Your username.
 
 * **`Secret`**:
-  Select a `Secret` from the drop-down list. If the list is empty, then you need to first [create a secret](../resources/asset-resource-secret) to be able to assign it here.
+  Select a `Secret` from the drop-down list. If the list is empty, then you need to first [create a secret](/docs/assets/workflow-assets/resources/asset-resource-secret) to be able to assign it here.
 
   Please [follow this link to "Advanced Concepts"](../../../concept/advanced/secret-management.md) to learn about the concept and use of the Security Storage.
 
@@ -109,5 +109,5 @@ The Reactive Engine must be able to reach the configured endpoint, or otherwise 
 :::
 
 :::tip Fields marked with "**macro supported**"
-You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 :::

--- a/docs/assets/workflow-assets/connections/asset-connection-smb.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-smb.md
@@ -20,8 +20,8 @@ Defines the connection parameters for a SMB endpoint.
 
 | Asset type | Link                                                |
 |------------|-----------------------------------------------------|
-| Source     | [SMB Source](../sources/asset-source-smb.md) |
-| Sink       | [SMB Sink](../sinks/asset-sink-smb)       |
+| Source     | [SMB Source](/docs/assets/workflow-assets/sources/asset-source-smb.md) |
+| Sink       | [SMB Sink](/docs/assets/workflow-assets/sinks/asset-sink-smb)       |
 
 ## Configuration
 

--- a/docs/assets/workflow-assets/connections/asset-connection-virtual-fs.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-virtual-fs.md
@@ -119,8 +119,8 @@ Validation of mount point paths occurs when a child asset that uses this connect
 
 - [**VFS Source**](/docs/assets/workflow-assets/sources/asset-source-virtual-fs.md) — Read files from a VFS mount
 - [**VFS Sink**](/docs/assets/workflow-assets/sinks/asset-sink-virtual-fs) — Write files to a VFS mount
-- [**SMB Connection**](../connections/asset-connection-smb) — SMB/CIFS backend for VFS
-- [**NFS Connection**](../connections/asset-connection-nfs) — NFS backend for VFS
+- [**SMB Connection**](/docs/assets/workflow-assets/connections/asset-connection-smb) — SMB/CIFS backend for VFS
+- [**NFS Connection**](/docs/assets/workflow-assets/connections/asset-connection-nfs) — NFS backend for VFS
 
 ---
 <WipDisclaimer></WipDisclaimer>

--- a/docs/assets/workflow-assets/connections/asset-connection-virtual-fs.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-virtual-fs.md
@@ -117,8 +117,8 @@ Validation of mount point paths occurs when a child asset that uses this connect
 
 ## See Also
 
-- [**VFS Source**](../sources/asset-source-virtual-fs.md) — Read files from a VFS mount
-- [**VFS Sink**](../sinks/asset-sink-virtual-fs) — Write files to a VFS mount
+- [**VFS Source**](/docs/assets/workflow-assets/sources/asset-source-virtual-fs.md) — Read files from a VFS mount
+- [**VFS Sink**](/docs/assets/workflow-assets/sinks/asset-sink-virtual-fs) — Write files to a VFS mount
 - [**SMB Connection**](../connections/asset-connection-smb) — SMB/CIFS backend for VFS
 - [**NFS Connection**](../connections/asset-connection-nfs) — NFS backend for VFS
 

--- a/docs/assets/workflow-assets/connections/asset-connection-webdav.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-webdav.md
@@ -16,8 +16,8 @@ Defines the connection parameters for a WebDav endpoint.
 
 | Asset type | Link                                                      |
 |------------|-----------------------------------------------------------|
-| Source     | [WebDav Source](../sources/asset-source-webdav.md) |
-| Sink       | [WebDav Sink](../sinks/asset-sink-webdav)       |
+| Source     | [WebDav Source](/docs/assets/workflow-assets/sources/asset-source-webdav.md) |
+| Sink       | [WebDav Sink](/docs/assets/workflow-assets/sinks/asset-sink-webdav)       |
 
 ## Configuration
 

--- a/docs/assets/workflow-assets/connections/asset-connection-webdav.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-webdav.md
@@ -63,7 +63,7 @@ You should be able to obtain the necessary parameters from your webdav provider 
   Your username.
 
 * **`Secret`**:
-  Select a `Secret` from the drop-down list. If the list is empty, then you need to first [create a secret](../resources/asset-resource-secret) to be able to assign it here.
+  Select a `Secret` from the drop-down list. If the list is empty, then you need to first [create a secret](/docs/assets/workflow-assets/resources/asset-resource-secret) to be able to assign it here.
 
   Please [follow this link to "Advanced Concepts"](../../../concept/advanced/secret-management.md) to learn about the concept and use of the Security Storage.
 
@@ -107,5 +107,5 @@ The Reactive Engine must be able to reach the configured endpoint, or otherwise 
 ---
 
 :::tip Fields marked with "**_macro supported_**"
-You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 :::

--- a/docs/assets/workflow-assets/extensions/asset-extension-aws.md
+++ b/docs/assets/workflow-assets/extensions/asset-extension-aws.md
@@ -106,6 +106,6 @@ Configure the **Parameter Store ARN** field to set a base ARN prefix. Then refer
 
 ## See Also
 
-- [Secret](../resources/asset-resource-secret) — Secure storage for sensitive values within layline.io
-- [Environment](../resources/asset-resource-environment) — Project-wide configuration values
+- [Secret](/docs/assets/workflow-assets/resources/asset-resource-secret) — Secure storage for sensitive values within layline.io
+- [Environment](/docs/assets/workflow-assets/resources/asset-resource-environment) — Project-wide configuration values
 - [Engine Configuration](../../deployment-assets/asset-deployment-engine) — Runtime configuration including "Other Resources"

--- a/docs/assets/workflow-assets/formats/asset-format-asn1.md
+++ b/docs/assets/workflow-assets/formats/asset-format-asn1.md
@@ -38,11 +38,11 @@ We will ensure that your case will be accommodated in the short term.
 
 | Asset type        | Link                                                                       |
 |-------------------|----------------------------------------------------------------------------|
-| Input Processors  | [Kafka Input](../processors-input/asset-input-kafka)                       |
-|                   | [Request-Response Input](../processors-input/asset-input-request-response) |
-|                   | [Stream Input](../processors-input/asset-input-stream)                     |
-|                   | [Frame Input](../processors-input/asset-input-frame)                       |
-| Output Processors | [Stream Output](../processors-output/asset-output-stream)                  |
+| Input Processors  | [Kafka Input](/docs/assets/workflow-assets/processors-input/asset-input-kafka)                       |
+|                   | [Request-Response Input](/docs/assets/workflow-assets/processors-input/asset-input-request-response) |
+|                   | [Stream Input](/docs/assets/workflow-assets/processors-input/asset-input-stream)                     |
+|                   | [Frame Input](/docs/assets/workflow-assets/processors-input/asset-input-frame)                       |
+| Output Processors | [Stream Output](/docs/assets/workflow-assets/processors-output/asset-output-stream)                  |
 
 ## Configuration
 

--- a/docs/assets/workflow-assets/formats/asset-format-data-dictionary.md
+++ b/docs/assets/workflow-assets/formats/asset-format-data-dictionary.md
@@ -53,7 +53,7 @@ Some examples:
 
 | Asset type      | Link                                                                      |
 |-----------------|---------------------------------------------------------------------------|
-| Formats         | [Generic Format](../formats/asset-format-generic)               |
+| Formats         | [Generic Format](/docs/assets/workflow-assets/formats/asset-format-generic)               |
 | Flow Processors | [Filter & Routing](/docs/assets/workflow-assets/processors-flow/asset-flow-filterrouting) |
 |                 | [Javascript](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript)          |
 |                 | [Mapping](/docs/assets/workflow-assets/processors-flow/asset-flow-mapping)                |

--- a/docs/assets/workflow-assets/formats/asset-format-data-dictionary.md
+++ b/docs/assets/workflow-assets/formats/asset-format-data-dictionary.md
@@ -54,10 +54,10 @@ Some examples:
 | Asset type      | Link                                                                      |
 |-----------------|---------------------------------------------------------------------------|
 | Formats         | [Generic Format](../formats/asset-format-generic)               |
-| Flow Processors | [Filter & Routing](../processors-flow/asset-flow-filterrouting) |
-|                 | [Javascript](../processors-flow/asset-flow-javascript)          |
-|                 | [Mapping](../processors-flow/asset-flow-mapping)                |
-|                 | [Stream Boundary](../processors-flow/asset-flow-streamboundary) |
+| Flow Processors | [Filter & Routing](/docs/assets/workflow-assets/processors-flow/asset-flow-filterrouting) |
+|                 | [Javascript](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript)          |
+|                 | [Mapping](/docs/assets/workflow-assets/processors-flow/asset-flow-mapping)                |
+|                 | [Stream Boundary](/docs/assets/workflow-assets/processors-flow/asset-flow-streamboundary) |
 
 ## Configuration
 

--- a/docs/assets/workflow-assets/formats/asset-format-generic.md
+++ b/docs/assets/workflow-assets/formats/asset-format-generic.md
@@ -51,11 +51,11 @@ We will explain all of this in this document.
 
 | Asset type        | Link                                                      |
 |-------------------|-----------------------------------------------------------|
-| Input Processors  | [Stream Input](../processors-input/asset-input-stream)    |
-|                   | [Frame Input](../processors-input/asset-input-frame)      |
-|                   | [Kafka Input](../processors-input/asset-input-kafka)      |
-| Output Processors | [Stream Output](../processors-output/asset-output-stream) |
-|                   | [Frame Output](../processors-output/asset-output-frame)   |
+| Input Processors  | [Stream Input](/docs/assets/workflow-assets/processors-input/asset-input-stream)    |
+|                   | [Frame Input](/docs/assets/workflow-assets/processors-input/asset-input-frame)      |
+|                   | [Kafka Input](/docs/assets/workflow-assets/processors-input/asset-input-kafka)      |
+| Output Processors | [Stream Output](/docs/assets/workflow-assets/processors-output/asset-output-stream) |
+|                   | [Frame Output](/docs/assets/workflow-assets/processors-output/asset-output-frame)   |
 
 ## Configuration
 
@@ -1772,14 +1772,14 @@ to set up your format!
 
 **Input Processors**
 
-* [Stream Input](../processors-input/asset-input-stream)
-* [Frame Input](../processors-input/asset-input-frame)
-* [Kafka Input](../processors-input/asset-input-kafka)
+* [Stream Input](/docs/assets/workflow-assets/processors-input/asset-input-stream)
+* [Frame Input](/docs/assets/workflow-assets/processors-input/asset-input-frame)
+* [Kafka Input](/docs/assets/workflow-assets/processors-input/asset-input-kafka)
 
 **Output Processors**
 
-* [Stream Output](../processors-output/asset-output-stream)
-* [Frame Output Processor](../processors-output/asset-output-frame)
+* [Stream Output](/docs/assets/workflow-assets/processors-output/asset-output-stream)
+* [Frame Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-frame)
 
 ### External
 

--- a/docs/assets/workflow-assets/formats/asset-format-http.md
+++ b/docs/assets/workflow-assets/formats/asset-format-http.md
@@ -14,7 +14,7 @@ import WipDisclaimer from '../../../snippets/common/_wip-disclaimer.md'
 
 ## Purpose
 
-The Http-Format Asset defines Http-Rest-Interfaces which can be used together with a [Request-Response Input](../processors-input/asset-input-request-response) Processor.
+The Http-Format Asset defines Http-Rest-Interfaces which can be used together with a [Request-Response Input](/docs/assets/workflow-assets/processors-input/asset-input-request-response) Processor.
 Essentially you will be defining all the ways, an external entity can invoke a layline.io Workflow through an Http-interface.
 Each call will generate a message with an optional payload (depending on how you configure the format).
 The message then starts traversing the Workflow and can be subsequently be reacted to.
@@ -29,14 +29,14 @@ Some examples:
   An external system wants to query a layline.io instance for specific data by way of an Http-interface.
   layline.io provides this interface to receive the query, retrieve the necessary information and respond back to the querying system through the Http-interface.
 
-Please check the [Request-Response Input](../processors-input/asset-input-request-response) Processor for more insight and adequate examples.
+Please check the [Request-Response Input](/docs/assets/workflow-assets/processors-input/asset-input-request-response) Processor for more insight and adequate examples.
 
 ### This Asset can be used by:
 
 | Asset type       | Link                                                                 |
 |------------------|----------------------------------------------------------------------|
-| Input Processors | [Request-Response](../processors-input/asset-input-request-response) |
-| Source           | [Http Source](../sources/asset-source-http.md)                          |
+| Input Processors | [Request-Response](/docs/assets/workflow-assets/processors-input/asset-input-request-response) |
+| Source           | [Http Source](/docs/assets/workflow-assets/sources/asset-source-http)                          |
 
 ## Configuration
 
@@ -108,7 +108,7 @@ A new path will be created with some default parameters.
 * **`Http Path`**: The actual http url part of the path under which the http methods can be reached.
 
   Example: Let's assume you have configured a workflow to handle incoming http requests.
-  The workflow has a [Request-Response Input](../processors-input/asset-input-request-response) which is bound to a Source Asset which opens port 4712 under address `https://mycluster.mydomain.com`.
+  The workflow has a [Request-Response Input](/docs/assets/workflow-assets/processors-input/asset-input-request-response) which is bound to a Source Asset which opens port 4712 under address `https://mycluster.mydomain.com`.
   Then given this path configuration you can access it under `htttps://mycluster.mydomain.com:4712/apaleo`.
 
 * **`Header Parameters`**: These are the header parameters which you would like to access in the course of handling the http-call.

--- a/docs/assets/workflow-assets/formats/asset-format-xml.md
+++ b/docs/assets/workflow-assets/formats/asset-format-xml.md
@@ -19,8 +19,8 @@ Define an XML data format based on an XSD schema. The XSD schema is parsed to ex
 
 Formats defined this way may be used to both read and write XML data. The format can be attached to:
 
-- [Stream Input](../processors-input/asset-input-stream) / [Stream Output](../processors-output/asset-output-stream)
-- [Frame Input](../processors-input/asset-input-frame) / [Frame Output](../processors-output/asset-output-frame)
+- [Stream Input](/docs/assets/workflow-assets/processors-input/asset-input-stream) / [Stream Output](/docs/assets/workflow-assets/processors-output/asset-output-stream)
+- [Frame Input](/docs/assets/workflow-assets/processors-input/asset-input-frame) / [Frame Output](/docs/assets/workflow-assets/processors-output/asset-output-frame)
 
 The editor enables you to:
 
@@ -110,7 +110,7 @@ Click **Add Converter** to add a new converter entry.
 
 ![Converters — context and pre-defined converter type selection](./.asset-format-xml_images/converters.png)
 
-For more on using formats in processors, see [Stream Input](../processors-input/asset-input-stream) and [Frame Input](../processors-input/asset-input-frame).
+For more on using formats in processors, see [Stream Input](/docs/assets/workflow-assets/processors-input/asset-input-stream) and [Frame Input](/docs/assets/workflow-assets/processors-input/asset-input-frame).
 
 ---
 

--- a/docs/assets/workflow-assets/processors-flow/asset-flow-ai-classifier.md
+++ b/docs/assets/workflow-assets/processors-flow/asset-flow-ai-classifier.md
@@ -241,8 +241,8 @@ The JavaScript Processor first extracts and validates the raw fields. The AI Cla
 ## See Also
 
 - [AI Trainer](./asset-flow-ai-trainer) — for training new AI models before using them with this Processor
-- [AI Model Resource](../resources/asset-resource-ai-model.md) — for defining the model's input/output schema, algorithm type, and hyperparameters
-- [AI Service](../services/asset-service-ai.md) — for defining the interface to an AI model
+- [AI Model Resource](/docs/assets/workflow-assets/resources/asset-resource-ai-model.md) — for defining the model's input/output schema, algorithm type, and hyperparameters
+- [AI Service](/docs/assets/workflow-assets/services/asset-service-ai.md) — for defining the interface to an AI model
 - [QuickScript Language Reference](../../../language-reference/quickscript/index.mdx) — for the expression language used in rule conditions
 - [Using Artificial Intelligence in Workflows](../../../concept/advanced/artificial-intelligence.md) — conceptual overview of supervised learning in layline.io
 

--- a/docs/assets/workflow-assets/processors-flow/asset-flow-ai-trainer.md
+++ b/docs/assets/workflow-assets/processors-flow/asset-flow-ai-trainer.md
@@ -42,7 +42,7 @@ Each training run creates a new **version** of the model in AI Storage, identifi
 
 This processor requires:
 
-1. An **[AI Model Resource](../resources/asset-resource-ai-model.md)** that defines the model's input/output attributes, model type (e.g., J48 Decision Tree, Multilayer Perceptron), and hyperparameters
+1. An **[AI Model Resource](/docs/assets/workflow-assets/resources/asset-resource-ai-model.md)** that defines the model's input/output attributes, model type (e.g., J48 Decision Tree, Multilayer Perceptron), and hyperparameters
 2. A path in AI Storage where the trained model will be stored
 3. Incoming messages with attribute values that can be mapped to the model's input schema
 
@@ -221,8 +221,8 @@ The JavaScript Processor extracts and formats the relevant attributes from each 
 ## See Also
 
 - [AI Classifier](./asset-flow-ai-classifier) — for applying a trained model to classify new messages
-- [AI Model Resource](../resources/asset-resource-ai-model.md) — for defining the model's input/output schema, algorithm type, and hyperparameters
-- [AI Service](../services/asset-service-ai) — for defining the interface to an AI model
+- [AI Model Resource](/docs/assets/workflow-assets/resources/asset-resource-ai-model.md) — for defining the model's input/output schema, algorithm type, and hyperparameters
+- [AI Service](/docs/assets/workflow-assets/services/asset-service-ai) — for defining the interface to an AI model
 - [Operations → AI Storage](../../../operations/cluster/ai-storage.md) — for managing trained models in AI Storage
 - [Using Artificial Intelligence in Workflows](../../../concept/advanced/artificial-intelligence) — conceptual overview of supervised learning in layline.io
 

--- a/docs/assets/workflow-assets/processors-flow/asset-flow-filterrouting.mdx
+++ b/docs/assets/workflow-assets/processors-flow/asset-flow-filterrouting.mdx
@@ -148,7 +148,7 @@ In this section you can define how the system should behave in case of such prob
 ## My filter and routing requirements cannot be met.
 
 If this Filter & Routing Asset is not sufficient because your requirements are based on more complex rules and potentially require additional information to determine what to filter and where to
-route, you can always use the [Javascript Flow Processor Asset](../processors-flow/asset-flow-javascript) to freely handle message filtering, routing, and whatever else you plan to do with
+route, you can always use the [Javascript Flow Processor Asset](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript) to freely handle message filtering, routing, and whatever else you plan to do with
 the message.
 
 

--- a/docs/assets/workflow-assets/processors-flow/asset-flow-input-frame-committer.md
+++ b/docs/assets/workflow-assets/processors-flow/asset-flow-input-frame-committer.md
@@ -156,8 +156,8 @@ If the same pattern used `Entire Stream` mode instead, the processor would emit 
 
 ## See Also
 
-- [SQS Source](../sources/asset-source-sqs.md) — message source that attaches `InputFrame` to SQS messages
-- [Kafka Source](../sources/asset-source-kafka.md) — message source that attaches `InputFrame` to Kafka records
+- [SQS Source](/docs/assets/workflow-assets/sources/asset-source-sqs) — message source that attaches `InputFrame` to SQS messages
+- [Kafka Source](/docs/assets/workflow-assets/sources/asset-source-kafka) — message source that attaches `InputFrame` to Kafka records
 - [Input Frame Processor](asset-flow-input-frame-committer.md) — counterpart that attaches `InputFrame` to messages; Input Frame Committer finalizes messages that carry it
 
 ---

--- a/docs/assets/workflow-assets/processors-flow/asset-flow-javascript.md
+++ b/docs/assets/workflow-assets/processors-flow/asset-flow-javascript.md
@@ -78,7 +78,7 @@ the [Javascript Language Reference](../../../language-reference/javascript/javas
 ### Service Mappings
 
 Javascripts may make use of Services which you may have
-configured [here](../services/asset-service-introduction.md#purpose-of-services). These methods could be database
+configured [here](/docs/assets/workflow-assets/services/asset-service-introduction.md#purpose-of-services). These methods could be database
 operations, HTTP-request and whatever else Services do provide.
 
 Let's say your Javascript invokes an HTTP-Service which provides a method to retrieve the current Bitcoin price via a

--- a/docs/assets/workflow-assets/processors-flow/asset-flow-python.md
+++ b/docs/assets/workflow-assets/processors-flow/asset-flow-python.md
@@ -78,7 +78,7 @@ the [Python Language Reference](../../../language-reference/python/python_introd
 ### Service Mappings
 
 Python scripts may make use of Services which you may have
-configured [here](../services/asset-service-introduction.md#purpose-of-services). These methods could be database
+configured [here](/docs/assets/workflow-assets/services/asset-service-introduction.md#purpose-of-services). These methods could be database
 operations, HTTP-request and whatever else Services do provide.
 
 Let's say your Python script invokes an HTTP-Service which provides a method to retrieve the current Bitcoin price via a

--- a/docs/assets/workflow-assets/processors-input/asset-input-frame.md
+++ b/docs/assets/workflow-assets/processors-input/asset-input-frame.md
@@ -28,8 +28,8 @@ This Asset is used within a Workflow definition.
 ### Prerequisite
 
 You need:
-* [SQS Source](../sources/asset-source-sqs.md), or
-* [UDP Source](../sources/asset-source-udp.md)
+* [SQS Source](/docs/assets/workflow-assets/sources/asset-source-sqs.md), or
+* [UDP Source](/docs/assets/workflow-assets/sources/asset-source-udp.md)
 * [Format](../formats)
 
 ## Configuration

--- a/docs/assets/workflow-assets/processors-input/asset-input-kafka.md
+++ b/docs/assets/workflow-assets/processors-input/asset-input-kafka.md
@@ -31,7 +31,7 @@ You need:
 
 **A Kafka Sink:**
 
-* [Source Kafka](../sources/asset-source-kafka.md)
+* [Source Kafka](/docs/assets/workflow-assets/sources/asset-source-kafka.md)
 
 ## Configuration
 
@@ -75,7 +75,7 @@ If you have defined such a format, then you can select it from the list of avail
 
 ### Kafka Source
 
-You need to assign a [Kafka Source](../sources/asset-source-kafka.md). The Source defines which topics can be read from.
+You need to assign a [Kafka Source](/docs/assets/workflow-assets/sources/asset-source-kafka.md). The Source defines which topics can be read from.
 The Source must have been previously defined.
 
 ![](.asset-input-kafka_images/cd27054a.png "Format (Input Kafka)")
@@ -127,7 +127,7 @@ You can read more about this in the [Kafka Documentation here](https://kafka.apa
 
 Define one or more topics that this input processor should read from.
 If you have defined a consumer group then the topics which you define here will be accessed with the same consumer group.
-You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 
 ![](.asset-input-kafka_images/c65fca67.png "Topics (Input Kafka)")
 
@@ -162,7 +162,7 @@ The SavePoint commit mode has no equivalent in Kafka. This actually represents "
 There are mechanisms within layline.io which allow to trigger a so called "upstream savepoint" based on certain conditions.
 If such a savepoint is triggered, this is then propagated back up. In this case the then current offset will be committed back to Kafka.
 
-An example can be found in the [Stream Boundary Controller Asset](../processors-flow/asset-flow-streamboundary) where a savepoint can be triggered upon configurable conditions.
+An example can be found in the [Stream Boundary Controller Asset](/docs/assets/workflow-assets/processors-flow/asset-flow-streamboundary) where a savepoint can be triggered upon configurable conditions.
 So if you have a Stream Boundary Controller in you Workflow, then a savepoint can be triggered from within that Processor.
 
 **Example:** Stream Boundary Controller SavePoint trigger
@@ -197,7 +197,7 @@ The Message Mode commits the read offset back to Kafka based on time and number 
 
 ### Internal
 
-* [Stream Boundary Controller Asset](../processors-flow/asset-flow-streamboundary)
+* [Stream Boundary Controller Asset](/docs/assets/workflow-assets/processors-flow/asset-flow-streamboundary)
 
 ### External
 

--- a/docs/assets/workflow-assets/processors-input/asset-input-kafka.md
+++ b/docs/assets/workflow-assets/processors-input/asset-input-kafka.md
@@ -25,9 +25,9 @@ This Asset is used within a Workflow definition.
 You need:
 **A defined Format**
 
-* [Format Generic](../formats/asset-format-generic)
-* [Format Data Dictionary](../formats/asset-format-data-dictionary)
-* [Format ASN.1](../formats/asset-format-asn1)
+* [Format Generic](/docs/assets/workflow-assets/formats/asset-format-generic)
+* [Format Data Dictionary](/docs/assets/workflow-assets/formats/asset-format-data-dictionary)
+* [Format ASN.1](/docs/assets/workflow-assets/formats/asset-format-asn1)
 
 **A Kafka Sink:**
 

--- a/docs/assets/workflow-assets/processors-input/asset-input-message.md
+++ b/docs/assets/workflow-assets/processors-input/asset-input-message.md
@@ -24,8 +24,8 @@ This Asset is used within a Workflow definition.
 
 You need:
 
-* [Timer Source](../sources/asset-source-timer.md), or
-* [Email Source](../sources/asset-source-email.md)
+* [Timer Source](/docs/assets/workflow-assets/sources/asset-source-timer.md), or
+* [Email Source](/docs/assets/workflow-assets/sources/asset-source-email.md)
 
 ## Configuration
 
@@ -62,7 +62,7 @@ A Workflow shutdown at most goes through three phases:
 
 ### Source
 
-You need to assign either a [Timer Source](../sources/asset-source-timer.md) or [Email Source](../sources/asset-source-email.md). 
+You need to assign either a [Timer Source](/docs/assets/workflow-assets/sources/asset-source-timer.md) or [Email Source](/docs/assets/workflow-assets/sources/asset-source-email.md). 
 The Source defines the physical parameters to obtain the data.
 
 ![](.asset-input-message_images/e8a26a3e.png "Timer Source (Input Message)")
@@ -75,7 +75,7 @@ The Source defines the physical parameters to obtain the data.
 
 ### Internal
 
-* [Timer Source](../sources/asset-source-timer.md)
+* [Timer Source](/docs/assets/workflow-assets/sources/asset-source-timer.md)
 
 ---
 

--- a/docs/assets/workflow-assets/processors-input/asset-input-request-response.md
+++ b/docs/assets/workflow-assets/processors-input/asset-input-request-response.md
@@ -27,7 +27,7 @@ This Asset is used within a Workflow definition.
 
 You need:
 
-* [Http-Format](../formats/asset-format-http)
+* [Http-Format](/docs/assets/workflow-assets/formats/asset-format-http)
 * [Http-Source](../sources/asset-source-http.md)
 
 ## Configuration
@@ -49,8 +49,8 @@ and then click to follow, if any.
 
 ### Format
 
-Assign a [Http-Format](../formats/asset-format-http) which you have previously defined.
-This Input-Asset will process the requests and responses which are defined in that assigned [Http-Format](../formats/asset-format-http).
+Assign a [Http-Format](/docs/assets/workflow-assets/formats/asset-format-http) which you have previously defined.
+This Input-Asset will process the requests and responses which are defined in that assigned [Http-Format](/docs/assets/workflow-assets/formats/asset-format-http).
 The format will be applied on the incoming data so that it can be accessed via the data dictionary.
 
 ![Format Assignment (Input Request-Response)](.asset-input-request-response_images/4a80984c.png)

--- a/docs/assets/workflow-assets/processors-input/asset-input-request-response.md
+++ b/docs/assets/workflow-assets/processors-input/asset-input-request-response.md
@@ -28,7 +28,7 @@ This Asset is used within a Workflow definition.
 You need:
 
 * [Http-Format](/docs/assets/workflow-assets/formats/asset-format-http)
-* [Http-Source](../sources/asset-source-http.md)
+* [Http-Source](/docs/assets/workflow-assets/sources/asset-source-http.md)
 
 ## Configuration
 
@@ -57,7 +57,7 @@ The format will be applied on the incoming data so that it can be accessed via t
 
 ### Source
 
-Assign a [Http-Source](../sources/asset-source-http.md).
+Assign a [Http-Source](/docs/assets/workflow-assets/sources/asset-source-http.md).
 The Source defines the physical addresses and ports on how this Input Asset can be reached.
 
 ![Source Assignment (Input Request-Response)](.asset-input-request-response_images/11611cf6.png)

--- a/docs/assets/workflow-assets/processors-input/asset-input-service.md
+++ b/docs/assets/workflow-assets/processors-input/asset-input-service.md
@@ -25,7 +25,7 @@ This Asset is used within a Workflow definition.
 You need:
 **A Service Source**
 
-* [Service Source](../sources/asset-source-service.md)
+* [Service Source](/docs/assets/workflow-assets/sources/asset-source-service.md)
 
 ## Configuration
 
@@ -61,7 +61,7 @@ A Workflow shutdown at most goes through three phases:
 
 ### Source
 
-You need to assign a [Service Source](../sources/asset-source-service.md).
+You need to assign a [Service Source](/docs/assets/workflow-assets/sources/asset-source-service.md).
 The Service Source obtains and delivers the actual messages to this Input Asset.
 
 ![](.asset-input-service_images/22765d2c.png "Timer Source (Input Message)")
@@ -74,7 +74,7 @@ The Service Source obtains and delivers the actual messages to this Input Asset.
 
 ### Internal
 
-* [Timer Source](../sources/asset-source-timer.md)
+* [Timer Source](/docs/assets/workflow-assets/sources/asset-source-timer.md)
 
 ---
 

--- a/docs/assets/workflow-assets/processors-input/asset-input-stream.md
+++ b/docs/assets/workflow-assets/processors-input/asset-input-stream.md
@@ -31,14 +31,14 @@ You need:
 
 **A Stream Source, of either**
 
-* [File System Source](../sources/asset-source-file.md)
-* [FTP Source](../sources/asset-source-ftp.md)
-* [OneDrive Source](../sources/asset-source-onedrive.md)
-* [S3 Source](../sources/asset-source-s3.md)
-* [SharePoint Source](../sources/asset-source-sharepoint.md)
-* [SMB Source](../sources/asset-source-smb.md)
-* [TCP Source](../sources/asset-source-tcp.md)
-* [WebDav Source](../sources/asset-source-webdav.md)
+* [File System Source](/docs/assets/workflow-assets/sources/asset-source-file.md)
+* [FTP Source](/docs/assets/workflow-assets/sources/asset-source-ftp.md)
+* [OneDrive Source](/docs/assets/workflow-assets/sources/asset-source-onedrive.md)
+* [S3 Source](/docs/assets/workflow-assets/sources/asset-source-s3.md)
+* [SharePoint Source](/docs/assets/workflow-assets/sources/asset-source-sharepoint.md)
+* [SMB Source](/docs/assets/workflow-assets/sources/asset-source-smb.md)
+* [TCP Source](/docs/assets/workflow-assets/sources/asset-source-tcp.md)
+* [WebDav Source](/docs/assets/workflow-assets/sources/asset-source-webdav.md)
 
 ### Name & Description
 

--- a/docs/assets/workflow-assets/processors-output/asset-output-frame.md
+++ b/docs/assets/workflow-assets/processors-output/asset-output-frame.md
@@ -34,11 +34,11 @@ This Asset is used within a Workflow definition.
 You need:
 **A Sink, either one of:**
 
-* [EventBridge](../sinks/asset-sink-eventbridge)
-* [Kafka](../sinks/asset-sink-kafka)
-* [Kinesis](../sinks/asset-sink-kinesis)
-* [SNS](../sinks/asset-sink-sns)
-* [SQS](../sinks/asset-sink-sqs)
+* [EventBridge](/docs/assets/workflow-assets/sinks/asset-sink-eventbridge)
+* [Kafka](/docs/assets/workflow-assets/sinks/asset-sink-kafka)
+* [Kinesis](/docs/assets/workflow-assets/sinks/asset-sink-kinesis)
+* [SNS](/docs/assets/workflow-assets/sinks/asset-sink-sns)
+* [SQS](/docs/assets/workflow-assets/sinks/asset-sink-sqs)
 
 ## Configuration
 
@@ -131,16 +131,16 @@ In case the conditions are met, the message is then forwarded to an [EventBridge
 
   ![](.asset-output-frame_images/a6b1b590.png "Add EventBridge Event Bus (Output Frame)")
 
-  An Event Bus reference can be selected from Event Buses which you have already defined in an [Event Bridge Sink](../sinks/asset-sink-eventbridge),
+  An Event Bus reference can be selected from Event Buses which you have already defined in an [Event Bridge Sink](/docs/assets/workflow-assets/sinks/asset-sink-eventbridge),
   or you can define a term which returns the Event Bus name through a [Quickscript](../../../language-reference/quickscript/quickscript.md) term.
 
-    * **Constant**: Pick this option to select from Event Buses which you have defined in an [Event Bridge Sink](../sinks/asset-sink-eventbridge).
+    * **Constant**: Pick this option to select from Event Buses which you have defined in an [Event Bridge Sink](/docs/assets/workflow-assets/sinks/asset-sink-eventbridge).
       Select the available Event Buses from the drop-down on the right:
 
   ![Select pre-configured Event Bus (Output Frame)](.asset-output-frame_images/bc80c560.png)
 
     * **Calculated**: Enter a [Quickscript](../../../language-reference/quickscript/quickscript.md) term which evaluates to an Event Bus name.
-      You can also use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+      You can also use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
       Make sure the result is enclosed in quotes as a result to form a valid result string.
 
       ![](.asset-output-frame_images/c24d9aea.png "Define a calculated Event Bus term")
@@ -367,7 +367,7 @@ If exclusive access cannot be obtained, you will receive an error.
   the [Mapping Asset](../processors-flow/asset-flow-mapping) or via [Javascript](../processors-flow/asset-flow-javascript)).
 
 * **`Topic`**: Enter the name of the topic you want to exclusively obtain access to.
-  You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+  You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 
 ## Sink Settings for Kinesis
 
@@ -439,7 +439,7 @@ In case the conditions are met, the message is then forwarded to SNS in the form
   A Kinesis data stream is a category through which you can send and receive real-time streaming data.
   It acts as a durable and ordered log of the data records. The stream parameter is used to identify the stream to which you want to send or receive data.
 
-    * **Constant**: Pick this option to select from Streams which you have defined in a [Kinesis Sink](../sinks/asset-sink-kinesis).
+    * **Constant**: Pick this option to select from Streams which you have defined in a [Kinesis Sink](/docs/assets/workflow-assets/sinks/asset-sink-kinesis).
       Select an available stream from the drop-down on the right:
 
       ![](.asset-output-frame_images/9e956db9.png "Select pre-configured Kinesis Stream (Output Frame)")
@@ -447,7 +447,7 @@ In case the conditions are met, the message is then forwarded to SNS in the form
       Alternatively, simply enter the name of the stream.
 
     * **Calculated**: Enter a [Quickscript](../../../language-reference/quickscript/quickscript.md) term which evaluates to an SNS topic name.
-      You can also use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+      You can also use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
       Make sure the result is enclosed in quotes as a result to form a valid result string.
 
       ![](.asset-output-frame_images/dd7d8b93.png "Define a calculated Kinesis Stream term")
@@ -467,7 +467,7 @@ In case the conditions are met, the message is then forwarded to SNS in the form
       ![](.asset-output-frame_images/780d740e.png "Enter fixed Kinesis Partition Key (Output Frame)")
 
     * **Calculated**: Enter a [Quickscript](../../../language-reference/quickscript/quickscript.md) term which evaluates to Kinesis Partition Key.
-      You can also use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+      You can also use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
       Make sure the result is enclosed in quotes as a result to form a valid result string.
 
       ![](.asset-output-frame_images/7ff5ab22.png "Define a calculated Partition Key term")
@@ -540,7 +540,7 @@ In case the conditions are met, the message is then forwarded to SNS in the form
 
 * **`Topic`**: Enter a term (Constant) or a QuickScript (Calculated) which is passed to SNS as the topic name to which the data should be written.
 
-    * **Constant**: Pick this option to select from Topics which you have defined in an [SNS Sink](../sinks/asset-sink-sns).
+    * **Constant**: Pick this option to select from Topics which you have defined in an [SNS Sink](/docs/assets/workflow-assets/sinks/asset-sink-sns).
       Select the available topics from the drop-down on the right:
 
       ![](.asset-output-frame_images/e13973fe.png "Select pre-configured SNS Topic (Output Frame)")
@@ -548,7 +548,7 @@ In case the conditions are met, the message is then forwarded to SNS in the form
       Alternatively, simply enter the name of the topic.
 
     * **Calculated**: Enter a [Quickscript](../../../language-reference/quickscript/quickscript.md) term which evaluates to an SNS topic name.
-      You can also use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+      You can also use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
       Make sure the result is enclosed in quotes as a result to form a valid result string.
 
       ![](.asset-output-frame_images/bbe776b5.png "Define a calculated SNS Topic term")
@@ -746,7 +746,7 @@ In case the conditions are met, the message is then forwarded to SQS in the form
 
 * **`Queue`**: Enter a term (Constant) or a QuickScript (Calculated) which is passed to SQS as the queue name to which the data should be written.
 
-    * **Constant**: Pick this option to select from Queues which you have defined in an [SQS Sink](../sinks/asset-sink-sqs).
+    * **Constant**: Pick this option to select from Queues which you have defined in an [SQS Sink](/docs/assets/workflow-assets/sinks/asset-sink-sqs).
       Select the available Queues from the drop-down on the right:
 
       ![](.asset-output-frame_images/ddaba884.png)
@@ -754,7 +754,7 @@ In case the conditions are met, the message is then forwarded to SQS in the form
       Alternatively, simply enter the name of the topic.
 
     * **Calculated**: Enter a [Quickscript](../../../language-reference/quickscript/quickscript.md) term which evaluates to an SQS topic name.
-      You can also use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+      You can also use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
       Make sure the result is enclosed in quotes as a result to form a valid result string.
 
       ![](.asset-output-frame_images/8ce31e60.png "Define a calculated SQS Topic term")

--- a/docs/assets/workflow-assets/processors-output/asset-output-frame.md
+++ b/docs/assets/workflow-assets/processors-output/asset-output-frame.md
@@ -292,7 +292,7 @@ In case the conditions are met, the message is then forwarded to the topic and i
   You must have pre-defined the format [here](../formats).
   Please note that only the data which is part of the format in the data dictionary which you pick here will be written.
   So if you read the data in format `A`, but then want to output format `B`, then the relevant data must have been mapped from `A` to `B´ in a previous step (e.g. by way of
-  the [Mapping Asset](../processors-flow/asset-flow-mapping) or via [Javascript](../processors-flow/asset-flow-javascript)).
+  the [Mapping Asset](/docs/assets/workflow-assets/processors-flow/asset-flow-mapping) or via [Javascript](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript)).
 
 * **`Topic`**: Enter a [Quickscript](../../../language-reference/quickscript/quickscript.md) term which evaluates to the topic name of where you want to send the individual message.
   Let's assume your default topic name is "myTopic", then you simply enter "myTopic" (include quotes) in the field.
@@ -364,7 +364,7 @@ If exclusive access cannot be obtained, you will receive an error.
   You must have pre-defined the format [here](../formats).
   Please note that only the data which is part of the format in the data dictionary which you pick here will be written.
   So if you read the data in format `A`, but then want to output format `B`, then the relevant data must have been mapped from `A` to `B´ in a previous step (e.g. by way of
-  the [Mapping Asset](../processors-flow/asset-flow-mapping) or via [Javascript](../processors-flow/asset-flow-javascript)).
+  the [Mapping Asset](/docs/assets/workflow-assets/processors-flow/asset-flow-mapping) or via [Javascript](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript)).
 
 * **`Topic`**: Enter the name of the topic you want to exclusively obtain access to.
   You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
@@ -429,7 +429,7 @@ In case the conditions are met, the message is then forwarded to SNS in the form
   You must have pre-defined the format [here](../formats).
   Please note that only the data which is part of the format in the data dictionary which you pick here will be written.
   So if you read the data in format `A`, but then want to output format `B`, then the relevant data must have been mapped from `A` tpo `B´ in a previous step (e.g. by way of
-  the [Mapping Asset](../processors-flow/asset-flow-mapping) or via [Javascript](../processors-flow/asset-flow-javascript)).
+  the [Mapping Asset](/docs/assets/workflow-assets/processors-flow/asset-flow-mapping) or via [Javascript](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript)).
 
   ![](.asset-output-frame_images/38fa86be.png "Kinesis output format (Output Frame)")
 
@@ -534,7 +534,7 @@ In case the conditions are met, the message is then forwarded to SNS in the form
   You must have pre-defined the format [here](../formats).
   Please note that only the data which is part of the format in the data dictionary which you pick here will be written.
   So if you read the data in format `A`, but then want to output format `B`, then the relevant data must have been mapped from `A` tpo `B´ in a previous step (e.g. by way of
-  the [Mapping Asset](../processors-flow/asset-flow-mapping) or via [Javascript](../processors-flow/asset-flow-javascript)).
+  the [Mapping Asset](/docs/assets/workflow-assets/processors-flow/asset-flow-mapping) or via [Javascript](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript)).
 
   ![](.asset-output-frame_images/44ee1b0a.png "SNS output format (Output Frame)")
 
@@ -740,7 +740,7 @@ In case the conditions are met, the message is then forwarded to SQS in the form
   You must have pre-defined the format [here](../formats).
   Please note that only the data which is part of the format in the data dictionary which you pick here will be written.
   So if you read the data in format `A`, but then want to output format `B`, then the relevant data must have been mapped from `A` tpo `B´ in a previous step (e.g. by way of
-  the [Mapping Asset](../processors-flow/asset-flow-mapping) or via [Javascript](../processors-flow/asset-flow-javascript)).
+  the [Mapping Asset](/docs/assets/workflow-assets/processors-flow/asset-flow-mapping) or via [Javascript](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript)).
 
   ![](.asset-output-frame_images/328770d5.png "SQS output format (Output Frame)")
 

--- a/docs/assets/workflow-assets/processors-output/asset-output-stream.md
+++ b/docs/assets/workflow-assets/processors-output/asset-output-stream.md
@@ -28,14 +28,14 @@ You need:
 
 **A Stream Sink:**
 
-* [Sink File System](../sinks/asset-sink-file)
-* [Sink FTP](../sinks/asset-sink-ftp)
-* [Sink OneDrive](../sinks/asset-sink-onedrive)
-* [Sink S3](../sinks/asset-sink-s3)
-* [Sink Sharepoint](../sinks/asset-sink-sharepoint)
-* [Sink SMB](../sinks/asset-sink-smb)
-* [Sink WebDav](../sinks/asset-sink-webdav)
-* [Sink WebSocket](../sinks/asset-sink-websocket)
+* [Sink File System](/docs/assets/workflow-assets/sinks/asset-sink-file)
+* [Sink FTP](/docs/assets/workflow-assets/sinks/asset-sink-ftp)
+* [Sink OneDrive](/docs/assets/workflow-assets/sinks/asset-sink-onedrive)
+* [Sink S3](/docs/assets/workflow-assets/sinks/asset-sink-s3)
+* [Sink Sharepoint](/docs/assets/workflow-assets/sinks/asset-sink-sharepoint)
+* [Sink SMB](/docs/assets/workflow-assets/sinks/asset-sink-smb)
+* [Sink WebDav](/docs/assets/workflow-assets/sinks/asset-sink-webdav)
+* [Sink WebSocket](/docs/assets/workflow-assets/sinks/asset-sink-websocket)
 
 ### Name & Description
 

--- a/docs/assets/workflow-assets/processors-output/index.mdx
+++ b/docs/assets/workflow-assets/processors-output/index.mdx
@@ -82,7 +82,7 @@ Output Processors participate in Workflow transaction management:
 
 - Messages are committed to Sinks as part of the Workflow's transaction
 - Failed outputs can trigger rollback of the entire processing batch
-- Use [Input Frame Committer](../processors-flow/asset-flow-input-frame-committer) for precise control over when offsets are committed relative to output
+- Use [Input Frame Committer](/docs/assets/workflow-assets/processors-flow/asset-flow-input-frame-committer) for precise control over when offsets are committed relative to output
 
 ## See Also
 

--- a/docs/assets/workflow-assets/resources/asset-resource-ai-model.md
+++ b/docs/assets/workflow-assets/resources/asset-resource-ai-model.md
@@ -9,7 +9,7 @@ import WipDisclaimer from '../../../snippets/common/_wip-disclaimer.md'
 
 ## Purpose
 
-The **AI Model Resource** defines the technical specification for an AI model — its input and output attributes, the algorithm to use, and the hyperparameters that control how that algorithm trains. It is a shared definition used by both the [AI Trainer](../processors-flow/asset-flow-ai-trainer) (to train the model) and the [AI Classifier](../processors-flow/asset-flow-ai-classifier) (to apply it at runtime).
+The **AI Model Resource** defines the technical specification for an AI model — its input and output attributes, the algorithm to use, and the hyperparameters that control how that algorithm trains. It is a shared definition used by both the [AI Trainer](/docs/assets/workflow-assets/processors-flow/asset-flow-ai-trainer) (to train the model) and the [AI Classifier](/docs/assets/workflow-assets/processors-flow/asset-flow-ai-classifier) (to apply it at runtime).
 
 Before you can train or classify with an AI model, the model must be defined here.
 
@@ -163,7 +163,7 @@ Appears when `Weka Multilayer Perceptron` is selected as the Classifier.
 
 ### Model Training
 
-After defining an AI Model Resource, use it in an [AI Trainer](../processors-flow/asset-flow-ai-trainer) to train the model. The trained model is stored automatically in the cluster's AI Storage and can be referenced by an [AI Classifier](../processors-flow/asset-flow-ai-classifier) using the same path and version scheme.
+After defining an AI Model Resource, use it in an [AI Trainer](/docs/assets/workflow-assets/processors-flow/asset-flow-ai-trainer) to train the model. The trained model is stored automatically in the cluster's AI Storage and can be referenced by an [AI Classifier](/docs/assets/workflow-assets/processors-flow/asset-flow-ai-classifier) using the same path and version scheme.
 
 ### Attribute Matching
 
@@ -207,9 +207,9 @@ Reference the same model from AI Storage at `models/usage-classifier-v2:latest`.
 
 ## See Also
 
-- [AI Trainer](../processors-flow/asset-flow-ai-trainer) — train the model defined by this Resource
-- [AI Classifier](../processors-flow/asset-flow-ai-classifier) — apply the trained model to classify new messages
-- [AI Service](../services/asset-service-ai) — expose an AI model as a service endpoint
+- [AI Trainer](/docs/assets/workflow-assets/processors-flow/asset-flow-ai-trainer) — train the model defined by this Resource
+- [AI Classifier](/docs/assets/workflow-assets/processors-flow/asset-flow-ai-classifier) — apply the trained model to classify new messages
+- [AI Service](/docs/assets/workflow-assets/services/asset-service-ai) — expose an AI model as a service endpoint
 - [Using Artificial Intelligence in Workflows](../../../concept/advanced/artificial-intelligence.md) — conceptual overview of supervised learning in layline.io
 
 ---

--- a/docs/assets/workflow-assets/resources/asset-resource-data-dictionary-updates.md
+++ b/docs/assets/workflow-assets/resources/asset-resource-data-dictionary-updates.md
@@ -19,7 +19,7 @@ You can extend this global dictionary in two ways:
 
 The Resource exists for situations where you need a small data structure — for example a shared enum, a simple sequence used for internal bookkeeping, or a reusable type across Workflows — but where defining a complete Format Asset with input/output handling would be excessive.
 
-For full details of supported element types (Namespace, Sequence, Choice, Enumeration, Array, Map), see the [Data Dictionary Format](../formats/asset-format-data-dictionary.md) documentation.
+For full details of supported element types (Namespace, Sequence, Choice, Enumeration, Array, Map), see the [Data Dictionary Format](/docs/assets/workflow-assets/formats/asset-format-data-dictionary) documentation.
 
 ## Configuration
 
@@ -70,7 +70,7 @@ Once defined, any Asset in the Project can reference `Customer.Profile.CustomerI
 
 ## See Also
 
-- [Data Dictionary Format](../formats/asset-format-data-dictionary.md) — full reference for all element types, encoding configuration, and examples
+- [Data Dictionary Format](/docs/assets/workflow-assets/formats/asset-format-data-dictionary) — full reference for all element types, encoding configuration, and examples
 - [Data Dictionary Concept](../../../concept/data-dictionary.md) — architectural overview of how layline.io maintains and uses the global Data Dictionary
 
 ---

--- a/docs/assets/workflow-assets/resources/asset-resource-directories.md
+++ b/docs/assets/workflow-assets/resources/asset-resource-directories.md
@@ -85,8 +85,8 @@ When the Reactive Engine starts, it creates `input/`, `archive/`, and `error/` d
 
 ## See Also
 
-- [Secret](../resources/asset-resource-secret) — for managing sensitive credentials alongside directory paths
-- [Environment](../resources/asset-resource-environment) — for environment-specific variable substitution
+- [Secret](/docs/assets/workflow-assets/resources/asset-resource-secret) — for managing sensitive credentials alongside directory paths
+- [Environment](/docs/assets/workflow-assets/resources/asset-resource-environment) — for environment-specific variable substitution
 - [Macros](../../../language-reference/macros) — for using macros in directory paths and permission strings
 
 ---

--- a/docs/assets/workflow-assets/resources/asset-resource-oauth-client.md
+++ b/docs/assets/workflow-assets/resources/asset-resource-oauth-client.md
@@ -46,7 +46,7 @@ The Secrets table stores one or more client secrets associated with this OAuth c
 
 **`Valid until`** — an optional expiry date. If set, the secret is considered invalid after this date.
 
-**`Secret`** — the secret value. Enable **Use a secret** to reference a value from [Secret Storage](../resources/asset-resource-secret), or disable it to enter a raw secret value directly.
+**`Secret`** — the secret value. Enable **Use a secret** to reference a value from [Secret Storage](/docs/assets/workflow-assets/resources/asset-resource-secret), or disable it to enter a raw secret value directly.
 
 **`Ops`** — remove this secret entry.
 
@@ -67,7 +67,7 @@ The Secrets table stores one or more client secrets associated with this OAuth c
 
 ## See Also
 
-- [Secret](../resources/asset-resource-secret) — for storing secret values in Secret Storage and referencing them in this Resource
+- [Secret](/docs/assets/workflow-assets/resources/asset-resource-secret) — for storing secret values in Secret Storage and referencing them in this Resource
 - [Secret Management (Concept)](../../../concept/advanced/secret-management.md) — overview of how layline.io manages credentials
 
 ---

--- a/docs/assets/workflow-assets/resources/asset-resource-secret.md
+++ b/docs/assets/workflow-assets/resources/asset-resource-secret.md
@@ -28,7 +28,7 @@ So we really have two requirements here in regard to handling confidential infor
 
    Be able to define different Secret Environments, for different target environments such as development, testing, and production.
 
-What's needed is very similar to how we are using variables from [Environment Assets](../resources/asset-resource-environment).
+What's needed is very similar to how we are using variables from [Environment Assets](/docs/assets/workflow-assets/resources/asset-resource-environment).
 There we reference Environment Variables with [macros](../../../language-reference/macros.md#lay).
 It works the same way with Secrets, only the [prefix (sec)](../../../language-reference/macros.md#sec) is different.
 

--- a/docs/assets/workflow-assets/resources/asset-resource-status-definition.md
+++ b/docs/assets/workflow-assets/resources/asset-resource-status-definition.md
@@ -194,8 +194,8 @@ params = status.parameters   # ['42', 'orders']
 
 ## See Also
 
-- [Secret](../resources/asset-resource-secret) — for storing secret values alongside status definitions
-- [Environment](../resources/asset-resource-environment) — for environment-specific configuration
+- [Secret](/docs/assets/workflow-assets/resources/asset-resource-secret) — for storing secret values alongside status definitions
+- [Environment](/docs/assets/workflow-assets/resources/asset-resource-environment) — for environment-specific configuration
 
 ---
 

--- a/docs/assets/workflow-assets/resources/index.mdx
+++ b/docs/assets/workflow-assets/resources/index.mdx
@@ -8,7 +8,7 @@ title: Resources
 
 ## Overview
 
-Resources in layline.io provide a way to externalize configuration from individual assets. Instead of hardcoding credentials, paths, or environment-specific values directly into Connections, Processors, or Services, you define them in a Resource and reference them using [macros](../../../language-reference/macros).
+Resources in layline.io provide a way to externalize configuration from individual assets. Instead of hardcoding credentials, paths, or environment-specific values directly into Connections, Processors, or Services, you define them in a Resource and reference them using [macros](/docs/language-reference/macros).
 
 This separation of configuration from logic enables:
 
@@ -79,6 +79,6 @@ Never hardcode credentials or environment-specific paths in asset configurations
 - [**Connections**](../connections/asset-connection-aws) — Reusable connection parameters for external systems (often reference Secrets and Environment variables)
 - [**Services**](/docs/assets/workflow-assets/services/asset-service-http) — External API and database integrations (use Resources for credentials and endpoint configuration)
 - [**Deployment Assets**](../../deployment-assets/) — How Resources are included in deployments and combined with environment-specific values
-- [**Macros**](../../../language-reference/macros) — Syntax for referencing Resource values in asset configurations
+- [**Macros**](/docs/language-reference/macros) — Syntax for referencing Resource values in asset configurations
 - [**Secret Management**](../../../concept/advanced/secret-management.md) — Architectural overview of credential encryption and storage
 

--- a/docs/assets/workflow-assets/resources/index.mdx
+++ b/docs/assets/workflow-assets/resources/index.mdx
@@ -77,7 +77,7 @@ Never hardcode credentials or environment-specific paths in asset configurations
 ## See Also
 
 - [**Connections**](../connections/asset-connection-aws) — Reusable connection parameters for external systems (often reference Secrets and Environment variables)
-- [**Services**](../services/asset-service-http) — External API and database integrations (use Resources for credentials and endpoint configuration)
+- [**Services**](/docs/assets/workflow-assets/services/asset-service-http) — External API and database integrations (use Resources for credentials and endpoint configuration)
 - [**Deployment Assets**](../../deployment-assets/) — How Resources are included in deployments and combined with environment-specific values
 - [**Macros**](../../../language-reference/macros) — Syntax for referencing Resource values in asset configurations
 - [**Secret Management**](../../../concept/advanced/secret-management.md) — Architectural overview of credential encryption and storage

--- a/docs/assets/workflow-assets/services/asset-service-ai.md
+++ b/docs/assets/workflow-assets/services/asset-service-ai.md
@@ -320,7 +320,7 @@ def on_stream_end():
 
 - [AI Trainer](/docs/assets/workflow-assets/processors-flow/asset-flow-ai-trainer) — train and store models in AI Storage
 - [AI Classifier](/docs/assets/workflow-assets/processors-flow/asset-flow-ai-classifier) — use a trained model directly within a Workflow stream
-- [AI Model Resource](../resources/asset-resource-ai-model.md) — define the model specification used for training and by this service
+- [AI Model Resource](/docs/assets/workflow-assets/resources/asset-resource-ai-model.md) — define the model specification used for training and by this service
 - [Using Artificial Intelligence in Workflows](../../../concept/advanced/artificial-intelligence.md) — conceptual overview of supervised learning in layline.io
 
 ---

--- a/docs/assets/workflow-assets/services/asset-service-ai.md
+++ b/docs/assets/workflow-assets/services/asset-service-ai.md
@@ -16,7 +16,7 @@ The **AI Service** exposes one or more trained AI models as callable functions f
 ## Prerequisites
 
 - One or more **AI Model Resources** defining the model type, input/output schema, and hyperparameters
-- One or more **trained models** stored in AI Storage (trained by an [AI Trainer](../processors-flow/asset-flow-ai-trainer))
+- One or more **trained models** stored in AI Storage (trained by an [AI Trainer](/docs/assets/workflow-assets/processors-flow/asset-flow-ai-trainer))
 - A **Data Dictionary** with attributes defined in the namespace configured in the service
 
 :::tip
@@ -318,8 +318,8 @@ def on_stream_end():
 
 ## See Also
 
-- [AI Trainer](../processors-flow/asset-flow-ai-trainer) — train and store models in AI Storage
-- [AI Classifier](../processors-flow/asset-flow-ai-classifier) — use a trained model directly within a Workflow stream
+- [AI Trainer](/docs/assets/workflow-assets/processors-flow/asset-flow-ai-trainer) — train and store models in AI Storage
+- [AI Classifier](/docs/assets/workflow-assets/processors-flow/asset-flow-ai-classifier) — use a trained model directly within a Workflow stream
 - [AI Model Resource](../resources/asset-resource-ai-model.md) — define the model specification used for training and by this service
 - [Using Artificial Intelligence in Workflows](../../../concept/advanced/artificial-intelligence.md) — conceptual overview of supervised learning in layline.io
 

--- a/docs/assets/workflow-assets/services/asset-service-dynamo-db.md
+++ b/docs/assets/workflow-assets/services/asset-service-dynamo-db.md
@@ -267,7 +267,7 @@ result = dynamo_db_service.<Operation><FunctionName>({ /* parameters */ })
 
 4. **Handle the response** using the auto-generated result types in the Data Dictionary.
 
-For more information, see [JavaScript Processor](../processors-flow/asset-flow-javascript.md) or [Python Processor](../processors-flow/asset-flow-python).
+For more information, see [JavaScript Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript.md) or [Python Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-python).
 
 #### Example: Write
 

--- a/docs/assets/workflow-assets/services/asset-service-email.md
+++ b/docs/assets/workflow-assets/services/asset-service-email.md
@@ -23,7 +23,7 @@ Define a service to interface with Email.
 
 ## Prerequisites
 
-For this to work, you need a configured [Email Connection](../connections/asset-connection-email).
+For this to work, you need a configured [Email Connection](/docs/assets/workflow-assets/connections/asset-connection-email).
 
 ## Configuration
 
@@ -47,7 +47,7 @@ Configure the parameters for your Email Service:
 
 ![Email Connection drop-down list](./.asset-service-email_images/1714391942849.png "Email Connection drop-down list")
 
-Use the drop-down list to select a [Email Connection](../connections/asset-connection-email) that should
+Use the drop-down list to select a [Email Connection](/docs/assets/workflow-assets/connections/asset-connection-email) that should
 support this Email Service. If it does not exist, you need to create it first.
 
 #### More Settings

--- a/docs/assets/workflow-assets/services/asset-service-introduction.md
+++ b/docs/assets/workflow-assets/services/asset-service-introduction.md
@@ -32,7 +32,7 @@ Conceptually, this is what it looks like:
 
 What's happening here, is that a Processor (JavaScript Processor in image) makes use of a Service (JDBC Service in image) in a request/response pattern. 
 
-Services are usually used from within [Javascript Processor Assets](../processors-flow/asset-flow-javascript).
+Services are usually used from within [Javascript Processor Assets](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript).
 
 ### Service configuration
 

--- a/docs/assets/workflow-assets/services/asset-service-jdbc.md
+++ b/docs/assets/workflow-assets/services/asset-service-jdbc.md
@@ -66,7 +66,7 @@ JDBC requires a connection which is requires an address, username and password.
 ![](.asset-service-jdbc_images/b1913a15.png "JDBC Connection (Service JDBC)")
 
 You can use $\{...\} macros to expand variables defined
-in [environment variables](../resources/asset-resource-environment):
+in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment):
 
 ![](.asset-service-jdbc_images/8d1cf687.png "JDBC Connection with placeholders (Service JDBC)")
 

--- a/docs/assets/workflow-assets/services/asset-service-kvs.md
+++ b/docs/assets/workflow-assets/services/asset-service-kvs.md
@@ -147,7 +147,7 @@ def write_customer_data(customer_id, customer_data):
   </TabItem>
 </Tabs>
 
-For more information, see [JavaScript Processor](../processors-flow/asset-flow-javascript.md) or [Python Processor](../processors-flow/asset-flow-python).
+For more information, see [JavaScript Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript.md) or [Python Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-python).
 
 <Testcase></Testcase>
 

--- a/docs/assets/workflow-assets/services/asset-service-message.md
+++ b/docs/assets/workflow-assets/services/asset-service-message.md
@@ -49,8 +49,8 @@ A single Message Service can reference multiple Message Sources. For each Messag
 
 | Asset type | Link |
 |------------|------|
-| Processors | [JavaScript Processor](../processors-flow/asset-flow-javascript.md) |
-| | [Python Processor](../processors-flow/asset-flow-python.md) |
+| Processors | [JavaScript Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript.md) |
+| | [Python Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-python.md) |
 
 ### Related Asset
 
@@ -315,7 +315,7 @@ def on_order_confirmed(order_id, order_details):
 
 A downstream Workflow that references `OrderSource` will receive this message via its Input Processor and can process the confirmation further.
 
-For more on processors, see [JavaScript Processor](../processors-flow/asset-flow-javascript.md) and [Python Processor](../processors-flow/asset-flow-python.md).
+For more on processors, see [JavaScript Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript.md) and [Python Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-python.md).
 
 <Testcase></Testcase>
 

--- a/docs/assets/workflow-assets/services/asset-service-message.md
+++ b/docs/assets/workflow-assets/services/asset-service-message.md
@@ -19,7 +19,7 @@ import TabItem from '@theme/TabItem';
 
 ## Purpose
 
-The Message Service is the **producer side** of layline.io's internal publish/subscribe messaging system. It publishes messages to topics defined in a [Message Source](../sources/asset-source-message.md). Messages can be published from JavaScript or Python processors, making it useful for:
+The Message Service is the **producer side** of layline.io's internal publish/subscribe messaging system. It publishes messages to topics defined in a [Message Source](/docs/assets/workflow-assets/sources/asset-source-message). Messages can be published from JavaScript or Python processors, making it useful for:
 
 - Triggering downstream Workflows based on events
 - Broadcasting data to multiple consumers simultaneously
@@ -27,7 +27,7 @@ The Message Service is the **producer side** of layline.io's internal publish/su
 
 ### Architecture
 
-The Message Service is the counterpart to the [Message Source](../sources/asset-source-message.md) (consumer). Together they form a publish/subscribe system:
+The Message Service is the counterpart to the [Message Source](/docs/assets/workflow-assets/sources/asset-source-message) (consumer). Together they form a publish/subscribe system:
 
 ```mermaid
 flowchart LR
@@ -56,7 +56,7 @@ A single Message Service can reference multiple Message Sources. For each Messag
 
 | Asset | Description |
 |-------|-------------|
-| [Message Source](../sources/asset-source-message.md) | Defines the topics that this service publishes to |
+| [Message Source](/docs/assets/workflow-assets/sources/asset-source-message) | Defines the topics that this service publishes to |
 
 ## Configuration
 
@@ -78,7 +78,7 @@ Nodes (no restriction).
 
 ### Sources
 
-Under **Sources**, add references to the [Message Sources](../sources/asset-source-message.md) whose topics this service publishes to. Each entry links a Message Source asset to this service.
+Under **Sources**, add references to the [Message Sources](/docs/assets/workflow-assets/sources/asset-source-message) whose topics this service publishes to. Each entry links a Message Source asset to this service.
 
 | Column | Description |
 |--------|-------------|

--- a/docs/assets/workflow-assets/services/asset-service-proxy.md
+++ b/docs/assets/workflow-assets/services/asset-service-proxy.md
@@ -65,9 +65,9 @@ If you want this restriction, then enter the names of the `Required Roles` here.
 
 * **`User`** : Username to authenticate against the remote cluster.
 
-* **`Password`** : Password to authenticate against the remote cluster. This field does **not** accept a plain-text password. It is a dropdown that lists all secrets defined in your project's [Secret](../resources/asset-resource-secret) assets. Select the named secret you want to use (e.g. `proxy-password`). The secret value is resolved at runtime — it is never stored in clear text in the project configuration.
+* **`Password`** : Password to authenticate against the remote cluster. This field does **not** accept a plain-text password. It is a dropdown that lists all secrets defined in your project's [Secret](/docs/assets/workflow-assets/resources/asset-resource-secret) assets. Select the named secret you want to use (e.g. `proxy-password`). The secret value is resolved at runtime — it is never stored in clear text in the project configuration.
 
-  To create or manage secrets, see the [Secret Asset](../resources/asset-resource-secret) documentation.
+  To create or manage secrets, see the [Secret Asset](/docs/assets/workflow-assets/resources/asset-resource-secret) documentation.
 
 * **`Remote urls`** : List of remote URLs to proxy to. Each URL is entered on a separate line. When multiple URLs are provided, requests are routed to one of them (behaviour depends on the target service configuration).
 
@@ -89,7 +89,7 @@ On Cluster B, the `MyDBService` has this function:
 
 ### Step 1 — Create a Secret for Authentication
 
-Create a [Secret Asset](../resources/asset-resource-secret) in your project (e.g. `ClusterB_Credentials`). Add a key-value pair:
+Create a [Secret Asset](/docs/assets/workflow-assets/resources/asset-resource-secret) in your project (e.g. `ClusterB_Credentials`). Add a key-value pair:
 
 | Key | Value |
 |-----|-------|
@@ -135,6 +135,6 @@ export function onMessage() {
 
 ## See Also
 
-- [Secret Asset](../resources/asset-resource-secret) — managing encrypted credentials
+- [Secret Asset](/docs/assets/workflow-assets/resources/asset-resource-secret) — managing encrypted credentials
 - [Service Asset Introduction](./asset-service-introduction) — how services work in general
 - [Javascript Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript) — calling services from JavaScript

--- a/docs/assets/workflow-assets/services/asset-service-proxy.md
+++ b/docs/assets/workflow-assets/services/asset-service-proxy.md
@@ -137,4 +137,4 @@ export function onMessage() {
 
 - [Secret Asset](../resources/asset-resource-secret) — managing encrypted credentials
 - [Service Asset Introduction](./asset-service-introduction) — how services work in general
-- [Javascript Processor](../processors-flow/asset-flow-javascript) — calling services from JavaScript
+- [Javascript Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript) — calling services from JavaScript

--- a/docs/assets/workflow-assets/services/asset-service-seq.md
+++ b/docs/assets/workflow-assets/services/asset-service-seq.md
@@ -124,7 +124,7 @@ def reset_ticket_sequence(next_ticket_number):
   </TabItem>
 </Tabs>
 
-For more information, see [JavaScript Processor](../processors-flow/asset-flow-javascript.md) or [Python Processor](../processors-flow/asset-flow-python).
+For more information, see [JavaScript Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript.md) or [Python Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-python).
 
 <Testcase></Testcase>
 

--- a/docs/assets/workflow-assets/services/asset-service-soap.md
+++ b/docs/assets/workflow-assets/services/asset-service-soap.md
@@ -101,7 +101,7 @@ No authentication is performed / required.
   Your username.
 
 * **`Secret`**:
-  Select a `Secret` from the drop-down list. If the list is empty, then you need to first [create a secret](../resources/asset-resource-secret) to be able to assign it here.
+  Select a `Secret` from the drop-down list. If the list is empty, then you need to first [create a secret](/docs/assets/workflow-assets/resources/asset-resource-secret) to be able to assign it here.
 
   Please [follow this link to "Advanced Concepts"](../../../concept/advanced/secret-management.md) to learn about the concept and use of the Security Storage.
 

--- a/docs/assets/workflow-assets/services/asset-service-teams.md
+++ b/docs/assets/workflow-assets/services/asset-service-teams.md
@@ -25,7 +25,7 @@ Define a service to interface with Teams.
 
 ## Prerequisites
 
-For this to work, you need a configured [MS Graph Connection](../connections/asset-connection-msgraph).
+For this to work, you need a configured [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph).
 
 ## Configuration
 
@@ -49,11 +49,11 @@ Configure the parameters for your Teams Service:
 
 ![MSGraph Connection drop-down list](./.asset-service-teams_images/1714138476191.png "MSGraph Connection drop-down list")
 
-Use the drop-down list to select an [MS Graph Connection](../connections/asset-connection-msgraph) that should 
+Use the drop-down list to select an [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph) that should 
 support this Teams Service. If it does not exist, you need to create it first.
 
 :::info
-Your [MS Graph Connection](../connections/asset-connection-msgraph) needs to have the following configured scope:
+Your [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph) needs to have the following configured scope:
 * Team.ReadBasic.All
 * Channel.ReadBasic.All
 * Chat.ReadBasic

--- a/docs/assets/workflow-assets/services/asset-service-udp.md
+++ b/docs/assets/workflow-assets/services/asset-service-udp.md
@@ -47,7 +47,7 @@ Configure the connection parameters towards the UDP Service Server:
 * **`Timeout [ms]`**: Connection timeout in milliseconds. This is the time the client will wait for a connection to the UDP Service Server to be established.
 * **`Parallelism`**: number of requests to be handled at the same time.
 
-In here you can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+In here you can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 
 ### Default Formats
 

--- a/docs/assets/workflow-assets/services/asset-service-virtual-fs.md
+++ b/docs/assets/workflow-assets/services/asset-service-virtual-fs.md
@@ -16,7 +16,7 @@ import Testcase from '../../../snippets/assets/_asset-service-test.md';
 The Virtual File System Service provides file operations — read, write, copy, move, delete — against the Virtual File System from within a Javascript or Python Processor. It allows you to manage files programmatically in your script code, independent of any VFS Source or Sink.
 
 :::info
-The Virtual File System Service is a pure script-facing service. It has no input/output ports and cannot be used as a standalone processing step in a Workflow. It must be invoked from a [Javascript Processor](../processors-flow/asset-flow-javascript) or a [Python Processor](../processors-flow/asset-flow-python).
+The Virtual File System Service is a pure script-facing service. It has no input/output ports and cannot be used as a standalone processing step in a Workflow. It must be invoked from a [Javascript Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript) or a [Python Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-python).
 :::
 
 ## Configuration
@@ -37,7 +37,7 @@ If you want this restriction, then enter the names of the `Required Roles` here.
 
 ### Virtual FS Service Settings
 
-* **`Connection`** : Select the [Virtual File System Connection](../connections/asset-connection-virtual-fs) asset to use. This connection defines the mount points and storage backends (local filesystem, SMB, OneDrive, SharePoint, etc.) accessible to this service. The service will only be able to operate within the paths defined by that connection's mount points.
+* **`Connection`** : Select the [Virtual File System Connection](/docs/assets/workflow-assets/connections/asset-connection-virtual-fs) asset to use. This connection defines the mount points and storage backends (local filesystem, SMB, OneDrive, SharePoint, etc.) accessible to this service. The service will only be able to operate within the paths defined by that connection's mount points.
 
 ## Service Functions
 
@@ -56,7 +56,7 @@ The Virtual File System Service provides the following built-in functions:
 
 ### Step 1 — Create a Virtual File System Connection
 
-Before using the Virtual File System Service, configure a [Virtual File System Connection](../connections/asset-connection-virtual-fs) with the mount points you need to access. This connection defines which filesystem backends (local paths, SMB shares, OneDrive, SharePoint) are available.
+Before using the Virtual File System Service, configure a [Virtual File System Connection](/docs/assets/workflow-assets/connections/asset-connection-virtual-fs) with the mount points you need to access. This connection defines which filesystem backends (local paths, SMB shares, OneDrive, SharePoint) are available.
 
 ### Step 2 — Create the Virtual File System Service
 
@@ -64,7 +64,7 @@ Create a new **Virtual File System Service** Asset. In **Virtual FS Service Sett
 
 ### Step 3 — Map the Service in a Script Processor
 
-In your [Javascript Processor](../processors-flow/asset-flow-javascript) or [Python Processor](../processors-flow/asset-flow-python), add a **Service Mapping**:
+In your [Javascript Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript) or [Python Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-python), add a **Service Mapping**:
 
 * **Service**: Select your Virtual File System Service
 * **Logical Service Name**: `MyVfsService` (or any name you will use in your script)
@@ -225,6 +225,6 @@ The parameter names (`sourcePath`, `targetPath`, `path`, `content`) match the se
 
 ## See Also
 
-- [Virtual File System Connection](../connections/asset-connection-virtual-fs) — configuring mount points and storage backends
-- [JavaScript Processor](../processors-flow/asset-flow-javascript) — calling services from JavaScript
-- [Python Processor](../processors-flow/asset-flow-python) — calling services from Python
+- [Virtual File System Connection](/docs/assets/workflow-assets/connections/asset-connection-virtual-fs) — configuring mount points and storage backends
+- [JavaScript Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript) — calling services from JavaScript
+- [Python Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-python) — calling services from Python

--- a/docs/assets/workflow-assets/services/index.mdx
+++ b/docs/assets/workflow-assets/services/index.mdx
@@ -87,6 +87,6 @@ Services provide callable functions that workflows invoke during processing. Unl
 
 - [Services Introduction](./asset-service-introduction) — Detailed walkthrough of service concepts and usage patterns
 - [Connections](../connections/) — Reusable connection credentials for Email, Teams, and Virtual File System Services
-- [JavaScript Processor](../processors-flow/asset-flow-javascript) — Writing scripts that call services
-- [Python Processor](../processors-flow/asset-flow-python) — Python scripting with service integration
+- [JavaScript Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript) — Writing scripts that call services
+- [Python Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-python) — Python scripting with service integration
 

--- a/docs/assets/workflow-assets/sinks/asset-sink-eventbridge.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-eventbridge.md
@@ -17,13 +17,13 @@ Defines the outbound connection parameters for an AWS EventBridge sink.
 
 | Asset type        | Link                                                              |
 |-------------------|-------------------------------------------------------------------|
-| Output Processors | [Frame Output Processor](../processors-output/asset-output-frame) |
+| Output Processors | [Frame Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-frame) |
 
 ### Prerequisite
 
 You need:
 
-* [AWS Connection](../connections/asset-connection-aws)
+* [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws)
 
 ## Configuration
 
@@ -41,7 +41,7 @@ You need:
 
 ![AWS Connection (EventBridge Sink)](./.asset-sink-eventbridge_images/1722859138750.png "AWS Connection (EventBridge Sink)")
 
-Select the [AWS Connection](../connections/asset-connection-aws) to use with this Asset.
+Select the [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws) to use with this Asset.
 If it does not exist, you need to create it first.
 
 ### Event Buses
@@ -51,7 +51,7 @@ If it does not exist, you need to create it first.
 Once you picked an EventBridge Connection above the system will try to test the connection and
 show available event buses within the drop-down list under `ARN` (Amazon Resource Name).
 Having chosen an ARN the appropriate `Name` for referencing it when guiding resp. routing messages towards EventBridge sink queues within the
-_**Frame Output Processor**_ configurations will be selected. More details can be found [here](../processors-output/asset-output-frame.md#sink-settings-for-eventbridge).
+_**Frame Output Processor**_ configurations will be selected. More details can be found [here](/docs/assets/workflow-assets/processors-output/asset-output-frame.md#sink-settings-for-eventbridge).
 
 ---
 

--- a/docs/assets/workflow-assets/sinks/asset-sink-file.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-file.md
@@ -18,7 +18,7 @@ Defines the parameters for writing output files to the local file system. The Fi
 
 | Asset type        | Link                                                                |
 |-------------------|---------------------------------------------------------------------|
-| Output Processors | [Stream Output Processor](../processors-output/asset-output-stream) |
+| Output Processors | [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream) |
 
 ### Prerequisite
 
@@ -142,7 +142,7 @@ This configuration:
 
 ## See Also
 
-* [Stream Output Processor](../processors-output/asset-output-stream)
+* [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream)
 * [File System Source](../sources/asset-source-file.md)
 * [Environment Variables](../resources/asset-resource-environment)
 

--- a/docs/assets/workflow-assets/sinks/asset-sink-file.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-file.md
@@ -51,7 +51,7 @@ The Directories section defines where files are written and how they are handled
   * **Absolute** — e.g., `/tmp/layline/output` or `C:\layline\output`
   * **Relative** — Relative to the working directory of the Reactive Engine cluster node executing the workflow
   
-  You can use `$\{...\}` macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+  You can use `$\{...\}` macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 
 * **Output Prefix** — Prefix to add to the filename when writing to the output directory. E.g., `out_` will prepend `out_` to the filename.
 
@@ -143,8 +143,8 @@ This configuration:
 ## See Also
 
 * [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream)
-* [File System Source](../sources/asset-source-file.md)
-* [Environment Variables](../resources/asset-resource-environment)
+* [File System Source](/docs/assets/workflow-assets/sources/asset-source-file.md)
+* [Environment Variables](/docs/assets/workflow-assets/resources/asset-resource-environment)
 
 ---
 

--- a/docs/assets/workflow-assets/sinks/asset-sink-ftp.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-ftp.md
@@ -21,13 +21,13 @@ Defines the outbound connection parameters for an FTP sink.
 
 | Asset type        | Link                                                                          |
 |-------------------|-------------------------------------------------------------------------------|
-| Output Processors | [Stream Output Processor](../processors-output/asset-output-stream) |
+| Output Processors | [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream) |
 
 ### Prerequisite
 
 You need:
 
-* [FTP Connection](../connections/asset-connection-ftp)
+* [FTP Connection](/docs/assets/workflow-assets/connections/asset-connection-ftp)
 
 ## Configuration
 
@@ -43,7 +43,7 @@ You need:
 
 ![FTP Settings (FTP Sink Asset)](.asset-sink-ftp_images/067b010e.png)
 
-Select the [FTP Connection](../connections/asset-connection-ftp) to use with this Asset.
+Select the [FTP Connection](/docs/assets/workflow-assets/connections/asset-connection-ftp) to use with this Asset.
 If it does not exist, you need to create it first.
 
 ### Directories
@@ -54,9 +54,9 @@ If it does not exist, you need to create it first.
 
 ### Internal
 
-* [Stream Output Processor](../processors-output/asset-output-stream)
+* [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream)
 * [FTP Source](../sources/asset-source-ftp.md)
-* [FTP Connection](../connections/asset-connection-ftp)
+* [FTP Connection](/docs/assets/workflow-assets/connections/asset-connection-ftp)
 
 ---
 

--- a/docs/assets/workflow-assets/sinks/asset-sink-ftp.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-ftp.md
@@ -55,7 +55,7 @@ If it does not exist, you need to create it first.
 ### Internal
 
 * [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream)
-* [FTP Source](../sources/asset-source-ftp.md)
+* [FTP Source](/docs/assets/workflow-assets/sources/asset-source-ftp.md)
 * [FTP Connection](/docs/assets/workflow-assets/connections/asset-connection-ftp)
 
 ---

--- a/docs/assets/workflow-assets/sinks/asset-sink-gcs.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-gcs.md
@@ -135,7 +135,7 @@ If an object with that key already exists, it is replaced.
 ## See Also
 
 - [**Google Cloud Connection**](/docs/assets/workflow-assets/connections/asset-connection-google-cloud) — Authentication for GCS assets
-- [**GCS Source**](../sources/asset-source-google-cloud-storage.md) — Read objects from Google Cloud Storage
+- [**GCS Source**](/docs/assets/workflow-assets/sources/asset-source-google-cloud-storage.md) — Read objects from Google Cloud Storage
 
 ---
 <WipDisclaimer></WipDisclaimer>

--- a/docs/assets/workflow-assets/sinks/asset-sink-gcs.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-gcs.md
@@ -18,7 +18,7 @@ Writes messages to a Google Cloud Storage (GCS) bucket as objects. Each incoming
 
 ## Prerequisites
 
-- A [**Google Cloud Connection**](../connections/asset-connection-google-cloud) asset configured with the appropriate OAuth scopes.
+- A [**Google Cloud Connection**](/docs/assets/workflow-assets/connections/asset-connection-google-cloud) asset configured with the appropriate OAuth scopes.
 - A Google Cloud project with the Google Cloud Storage API enabled.
 - A GCS bucket in that project.
 
@@ -134,7 +134,7 @@ If an object with that key already exists, it is replaced.
 
 ## See Also
 
-- [**Google Cloud Connection**](../connections/asset-connection-google-cloud) — Authentication for GCS assets
+- [**Google Cloud Connection**](/docs/assets/workflow-assets/connections/asset-connection-google-cloud) — Authentication for GCS assets
 - [**GCS Source**](../sources/asset-source-google-cloud-storage.md) — Read objects from Google Cloud Storage
 
 ---

--- a/docs/assets/workflow-assets/sinks/asset-sink-kafka.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-kafka.md
@@ -84,10 +84,10 @@ Click **`ADD TOPIC`** to add new topics. Enter the **`Topic`** in the new table 
 
 ### Internal
 
-* [Kafka Input Processor](../processors-input/asset-input-kafka)
-* [Kafka Source](../sources/asset-source-kafka.md)
+* [Kafka Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-kafka)
+* [Kafka Source](/docs/assets/workflow-assets/sources/asset-source-kafka.md)
 * [Frame Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-frame)
-* [Create and manage secrets](../resources/asset-resource-secret)
+* [Create and manage secrets](/docs/assets/workflow-assets/resources/asset-resource-secret)
 
 ### External
 

--- a/docs/assets/workflow-assets/sinks/asset-sink-kafka.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-kafka.md
@@ -15,13 +15,13 @@ Defines the outbound connection parameters for a Kafka sink.
 
 | Asset type        | Link                                                              |
 |-------------------|-------------------------------------------------------------------|
-| Output Processors | [Frame Output Processor](../processors-output/asset-output-frame) |
+| Output Processors | [Frame Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-frame) |
 
 ### Prerequisite
 
 You need:
 
-* [Kafka Connection](../connections/asset-connection-kafka)
+* [Kafka Connection](/docs/assets/workflow-assets/connections/asset-connection-kafka)
 
 ## Configuration
 
@@ -47,7 +47,7 @@ If you want this restriction, then enter the names of the `Required Roles` here.
 
 ![](.asset-sink-kafka-images/a44e1dd8.png "Kafka Connection (Kafka Sink)")
 
-Select the [Kafka Connection](../connections/asset-connection-kafka) to use with this Asset.
+Select the [Kafka Connection](/docs/assets/workflow-assets/connections/asset-connection-kafka) to use with this Asset.
 If it does not exist, you need to create it first.
 
 ### Kafka Producer Settings
@@ -86,7 +86,7 @@ Click **`ADD TOPIC`** to add new topics. Enter the **`Topic`** in the new table 
 
 * [Kafka Input Processor](../processors-input/asset-input-kafka)
 * [Kafka Source](../sources/asset-source-kafka.md)
-* [Frame Output Processor](../processors-output/asset-output-frame)
+* [Frame Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-frame)
 * [Create and manage secrets](../resources/asset-resource-secret)
 
 ### External

--- a/docs/assets/workflow-assets/sinks/asset-sink-kinesis.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-kinesis.md
@@ -17,13 +17,13 @@ Defines the outbound connection parameters for an AWS Kinesis sink.
 
 | Asset type        | Link                                                              |
 |-------------------|-------------------------------------------------------------------|
-| Output Processors | [Frame Output Processor](../processors-output/asset-output-frame) |
+| Output Processors | [Frame Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-frame) |
 
 ### Prerequisite
 
 You need:
 
-* [AWS Connection](../connections/asset-connection-aws)
+* [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws)
 
 ## Configuration
 
@@ -41,7 +41,7 @@ You need:
 
 ![AWS Connection (Kinesis Sink)](./.asset-sink-kinesis_images/1722952769334.png "AWS Connection (Kinesis Sink)")
 
-Select the [AWS Connection](../connections/asset-connection-aws) to use with this Asset.
+Select the [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws) to use with this Asset.
 If it does not exist, you need to create it first.
 
 ### Streams
@@ -51,7 +51,7 @@ If it does not exist, you need to create it first.
 Once you picked a Kinesis Connection above the system will try to test the connection and
 show available data streams within the drop-down list under `ARN` (Amazon Resource Name).
 You can define a `Name` for each ARN in here to reference those when guiding resp. routing messages towards Kinesis sink queues within the
-_**Frame Output Processor**_ configurations will be selected. More details can be found [here](../processors-output/asset-output-frame.md#sink-settings-for-kinesis).
+_**Frame Output Processor**_ configurations will be selected. More details can be found [here](/docs/assets/workflow-assets/processors-output/asset-output-frame.md#sink-settings-for-kinesis).
 
 
 ---

--- a/docs/assets/workflow-assets/sinks/asset-sink-nfs.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-nfs.md
@@ -58,7 +58,7 @@ If it does not exist, you need to create it first.
 ### Internal
 
 * [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream)
-* [NFS Source](../sources/asset-source-nfs.md)
+* [NFS Source](/docs/assets/workflow-assets/sources/asset-source-nfs.md)
 * [NFS Connection](/docs/assets/workflow-assets/connections/asset-connection-nfs)
 
 ## Potential problems

--- a/docs/assets/workflow-assets/sinks/asset-sink-nfs.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-nfs.md
@@ -22,13 +22,13 @@ Defines the outbound connection parameters for an NFS sink.
 
 | Asset type        | Link                                                                          |
 |-------------------|-------------------------------------------------------------------------------|
-| Output Processors | [Stream Output Processor](../processors-output/asset-output-stream) |
+| Output Processors | [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream) |
 
 ### Prerequisite
 
 You need:
 
-* [NFS Connection](../connections/asset-connection-nfs)
+* [NFS Connection](/docs/assets/workflow-assets/connections/asset-connection-nfs)
 
 ## Configuration
 
@@ -46,7 +46,7 @@ You need:
 
 ![NFS Connection (NFS Sink)](.asset-sink-nfs_images/image_47.png "NFS Connection (NFS Sink)")
 
-Select the [NFS Connection](../connections/asset-connection-nfs) that you want to use with this Asset.
+Select the [NFS Connection](/docs/assets/workflow-assets/connections/asset-connection-nfs) that you want to use with this Asset.
 If it does not exist, you need to create it first.
 
 ### Directories
@@ -57,9 +57,9 @@ If it does not exist, you need to create it first.
 
 ### Internal
 
-* [Stream Output Processor](../processors-output/asset-output-stream)
+* [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream)
 * [NFS Source](../sources/asset-source-nfs.md)
-* [NFS Connection](../connections/asset-connection-nfs)
+* [NFS Connection](/docs/assets/workflow-assets/connections/asset-connection-nfs)
 
 ## Potential problems
 

--- a/docs/assets/workflow-assets/sinks/asset-sink-onedrive.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-onedrive.md
@@ -22,11 +22,11 @@ Defines the specific sink parameters for a OneDrive connected endpoint.
 
 | Asset type        | Link                                                                |
 |-------------------|---------------------------------------------------------------------|
-| Output Processors | [Stream Output Processor](../processors-output/asset-output-stream) |
+| Output Processors | [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream) |
 
 You need:
 
-* [MS Graph Connection](../connections/asset-connection-msgraph)
+* [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph)
 
 ## Configuration
 
@@ -50,11 +50,11 @@ Configure the parameters for your OneDrive endpoint:
 
 ![MSGraph Connection drop-down list](./.asset-sink-sharepoint_images/1714668065803.png "MSGraph Connection drop-down list")
 
-Use the drop-down list to select an [MS Graph Connection](../connections/asset-connection-msgraph) that should
+Use the drop-down list to select an [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph) that should
 support this OneDrive configuration. If it does not exist, you need to create it first.
 
 :::info
-Your [MS Graph Connection](../connections/asset-connection-msgraph) needs to have the following configured scope:
+Your [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph) needs to have the following configured scope:
 
 * Sites.ReadWrite.All
 * Files.ReadWrite.All

--- a/docs/assets/workflow-assets/sinks/asset-sink-s3.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-s3.md
@@ -23,13 +23,13 @@ This UI helps to define the outbound connection parameters for an AWS S3 sink.
 
 | Asset type        | Link                                                                |
 |-------------------|---------------------------------------------------------------------|
-| Output Processors | [Stream Output Processor](../processors-output/asset-output-stream) |
+| Output Processors | [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream) |
 
 ### Prerequisite
 
 You need:
 
-* [AWS Connection](../connections/asset-connection-aws)
+* [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws)
 
 ## Configuration
 
@@ -57,7 +57,7 @@ If you want this restriction, then enter the names of the `Required Roles` here.
 
 #### S3 Connection (A)
 
-Select the [AWS Connection](../connections/asset-connection-aws) to use for this Asset. If it does not exist, you need to create it first.
+Select the [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws) to use for this Asset. If it does not exist, you need to create it first.
 
 #### S3 Bucket (B)
 
@@ -86,7 +86,7 @@ The status of these attempts is displayed at the bottom of the group box.
 
 ### Internal
 
-* [S3 Connection](../connections/asset-connection-aws)
+* [S3 Connection](/docs/assets/workflow-assets/connections/asset-connection-aws)
 * [S3 Source](../sources/asset-source-s3.md)
 
 ### External

--- a/docs/assets/workflow-assets/sinks/asset-sink-s3.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-s3.md
@@ -87,7 +87,7 @@ The status of these attempts is displayed at the bottom of the group box.
 ### Internal
 
 * [S3 Connection](/docs/assets/workflow-assets/connections/asset-connection-aws)
-* [S3 Source](../sources/asset-source-s3.md)
+* [S3 Source](/docs/assets/workflow-assets/sources/asset-source-s3.md)
 
 ### External
 

--- a/docs/assets/workflow-assets/sinks/asset-sink-sharepoint.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-sharepoint.md
@@ -22,11 +22,11 @@ Defines the specific sink parameters for a SharePoint connected endpoint.
 
 | Asset type        | Link                                                                          |
 |-------------------|-------------------------------------------------------------------------------|
-| Output Processors | [Stream Output Processor](../processors-output/asset-output-stream) |
+| Output Processors | [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream) |
 
 You need:
 
-* [MS Graph Connection](../connections/asset-connection-msgraph)
+* [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph)
 
 ## Configuration
 
@@ -50,11 +50,11 @@ Configure the parameters for your SharePoint endpoint:
 
 ![MSGraph Connection drop-down list](./.asset-sink-sharepoint_images/1714668065803.png "MSGraph Connection drop-down list")
 
-Use the drop-down list to select an [MS Graph Connection](../connections/asset-connection-msgraph) that should
+Use the drop-down list to select an [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph) that should
 support this SharePoint configuration. If it does not exist, you need to create it first.
 
 :::info
-Your [MS Graph Connection](../connections/asset-connection-msgraph) needs to have the following configured scope:
+Your [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph) needs to have the following configured scope:
 * Sites.ReadWrite.All
 * Files.ReadWrite.All
 :::

--- a/docs/assets/workflow-assets/sinks/asset-sink-smb.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-smb.md
@@ -22,11 +22,11 @@ Defines the specific sink parameters for a SMB connected endpoint.
 
 | Asset type        | Link                                                                |
 |-------------------|---------------------------------------------------------------------|
-| Output Processors | [Stream Output Processor](../processors-output/asset-output-stream) |
+| Output Processors | [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream) |
 
 You need:
 
-* [SMB Connection](../connections/asset-connection-smb)
+* [SMB Connection](/docs/assets/workflow-assets/connections/asset-connection-smb)
 
 ## Configuration
 
@@ -48,7 +48,7 @@ Configure the parameters for your SMB endpoint:
 
 #### Connection
 
-Use the drop-down list to select an [SMB Connection](../connections/asset-connection-smb) that should
+Use the drop-down list to select an [SMB Connection](/docs/assets/workflow-assets/connections/asset-connection-smb) that should
 support this SMB configuration. If it does not exist, you need to create it first.
 
 #### Share

--- a/docs/assets/workflow-assets/sinks/asset-sink-smb.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-smb.md
@@ -54,7 +54,7 @@ support this SMB configuration. If it does not exist, you need to create it firs
 #### Share
 
 * **`Share`** : Configure your basic location information for your SMB endpoint.
-  You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+  You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 
 ### Directories
 

--- a/docs/assets/workflow-assets/sinks/asset-sink-sns.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-sns.md
@@ -17,13 +17,13 @@ Defines the outbound connection parameters for an AWS SNS (Simple Notification S
 
 | Asset type        | Link                                                              |
 |-------------------|-------------------------------------------------------------------|
-| Output Processors | [Frame Output Processor](../processors-output/asset-output-frame) |
+| Output Processors | [Frame Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-frame) |
 
 ### Prerequisite
 
 You need:
 
-* [AWS Connection](../connections/asset-connection-aws)
+* [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws)
 
 ## Configuration
 
@@ -41,7 +41,7 @@ You need:
 
 ![AWS Connection (SNS Sink)](./.asset-sink-sns_images/1723026564815.png "AWS Connection (SNS Sink)")
 
-Select the [AWS Connection](../connections/asset-connection-aws) to use with this Asset.
+Select the [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws) to use with this Asset.
 If it does not exist, you need to create it first.
 
 ### Topics
@@ -51,7 +51,7 @@ If it does not exist, you need to create it first.
 Once you picked an SNS Connection above the system will try to test the connection and
 show available topics within the drop-down list under `ARN` (Amazon Resource Name).
 You can define a `Name` for each ARN in here to reference those when guiding resp. routing messages towards SNS sink queues within the
-_**Frame Output Processor**_ configurations will be selected. More details can be found [here](../processors-output/asset-output-frame.md#sink-settings-for-sns).
+_**Frame Output Processor**_ configurations will be selected. More details can be found [here](/docs/assets/workflow-assets/processors-output/asset-output-frame.md#sink-settings-for-sns).
 
 ---
 

--- a/docs/assets/workflow-assets/sinks/asset-sink-sqs.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-sqs.md
@@ -23,13 +23,13 @@ This UI helps to define the outbound connection parameters for an AWS SQS sink.
 
 | Asset type        | Link                                                              |
 |-------------------|-------------------------------------------------------------------|
-| Output Processors | [Frame Output Processor](../processors-output/asset-output-frame) |
+| Output Processors | [Frame Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-frame) |
 
 ### Prerequisite
 
 You need:
 
-* [AWS Connection](../connections/asset-connection-aws)
+* [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws)
 
 ## Configuration
 
@@ -47,7 +47,7 @@ You need:
 
 ![AWS Connection (SQS Sink)](./.asset-sink-sqs_images/1715604361224.png "AWS Connection (SQS Sink)")
 
-Select the [AWS Connection](../connections/asset-connection-aws) to use with this Asset.
+Select the [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws) to use with this Asset.
 If it does not exist, you need to create it first.
 
 ### Queues
@@ -57,7 +57,7 @@ If it does not exist, you need to create it first.
 Once you picked a SQS Connection above the system will try to test the connection and
 show available queues within the drop-down list under `URL`.
 You can define a `Name` for each URL in here to reference those when guiding resp. routing messages towards SQS sink queues within the
-_**Frame Output Processor**_ configurations. More details can be found [here](../processors-output/asset-output-frame.md#sink-settings-for-sqs).
+_**Frame Output Processor**_ configurations. More details can be found [here](/docs/assets/workflow-assets/processors-output/asset-output-frame.md#sink-settings-for-sqs).
 
 ---
 

--- a/docs/assets/workflow-assets/sinks/asset-sink-virtual-fs.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-virtual-fs.md
@@ -20,13 +20,13 @@ Writes messages to a Virtual File System (VFS). The VFS abstraction allows the s
 
 | Asset type        | Link                                                                 |
 |-------------------|---------------------------------------------------------------------|
-| Output Processors | [Stream Output Processor](../processors-output/asset-output-stream) |
+| Output Processors | [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream) |
 
 ### Prerequisite
 
 You need:
 
-- A [**Virtual File System Connection**](../connections/asset-connection-virtual-fs)
+- A [**Virtual File System Connection**](/docs/assets/workflow-assets/connections/asset-connection-virtual-fs)
 
 ## Configuration
 
@@ -76,7 +76,7 @@ Based on these values the next processing will be delayed: starting with the min
 
 ![Virtual File System Settings (Virtual File System Sink)](./.Virtual_File_System_Sink_images/vfs-sink-vfs-settings.png "Virtual File System Settings (Virtual File System Sink)")
 
-**Connection** — Select the [Virtual File System Connection](../connections/asset-connection-virtual-fs) to use for writing files. If no connection exists, create one first.
+**Connection** — Select the [Virtual File System Connection](/docs/assets/workflow-assets/connections/asset-connection-virtual-fs) to use for writing files. If no connection exists, create one first.
 
 ### Directories
 
@@ -138,7 +138,7 @@ Temporary files that remain in the Temporary Directory after no active processin
 ## See Also
 
 - [**VFS Source**](../sources/asset-source-virtual-fs.md) — Read files from a VFS mount
-- [**VFS Connection**](../connections/asset-connection-virtual-fs) — VFS connection configuration
+- [**VFS Connection**](/docs/assets/workflow-assets/connections/asset-connection-virtual-fs) — VFS connection configuration
 - [**SMB Sink**](../sinks/asset-sink-smb) — Write files to SMB/CIFS shares
 
 ---

--- a/docs/assets/workflow-assets/sinks/asset-sink-virtual-fs.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-virtual-fs.md
@@ -137,7 +137,7 @@ Temporary files that remain in the Temporary Directory after no active processin
 
 ## See Also
 
-- [**VFS Source**](../sources/asset-source-virtual-fs.md) — Read files from a VFS mount
+- [**VFS Source**](/docs/assets/workflow-assets/sources/asset-source-virtual-fs.md) — Read files from a VFS mount
 - [**VFS Connection**](/docs/assets/workflow-assets/connections/asset-connection-virtual-fs) — VFS connection configuration
 - [**SMB Sink**](../sinks/asset-sink-smb) — Write files to SMB/CIFS shares
 

--- a/docs/assets/workflow-assets/sinks/asset-sink-webdav.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-webdav.md
@@ -22,13 +22,13 @@ Defines the specific sink parameters for a WebDAV connected endpoint.
 
 | Asset type        | Link                                                                |
 |-------------------|---------------------------------------------------------------------|
-| Output Processors | [Stream Output Processor](../processors-output/asset-output-stream) |
+| Output Processors | [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream) |
 
 ### Prerequisite
 
 You need:
 
-* [WebDAV Connection](../connections/asset-connection-webdav "Name & Description (WebDAV Sink Asset)")
+* [WebDAV Connection](/docs/assets/workflow-assets/connections/asset-connection-webdav "Name & Description (WebDAV Sink Asset)")
 
 ## Configuration
 
@@ -46,7 +46,7 @@ You need:
 
 ![](./.asset-sink-webdav_images/1723038026663.png "WebDAV Connection (WebDAV Sink Asset)")
 
-Select the [WebDAV Connection](../connections/asset-connection-webdav) to use with this Asset.
+Select the [WebDAV Connection](/docs/assets/workflow-assets/connections/asset-connection-webdav) to use with this Asset.
 If it does not exist, you need to create it first.
 
 ### Directories

--- a/docs/assets/workflow-assets/sinks/asset-sink-websocket.md
+++ b/docs/assets/workflow-assets/sinks/asset-sink-websocket.md
@@ -20,7 +20,7 @@ Defines the outbound connection parameters for a WebSocket sink. The sink acts a
 
 | Asset type         | Link                                                                          |
 |--------------------|-------------------------------------------------------------------------------|
-| Output Processors  | [Stream Output Processor](../processors-output/asset-output-stream) |
+| Output Processors  | [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream) |
 
 ### Prerequisite
 
@@ -58,7 +58,7 @@ No other assets are required to configure this sink. All connection parameters a
 
 ### Internal
 
-* [Stream Output Processor](../processors-output/asset-output-stream)
+* [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream)
 
 ---
 

--- a/docs/assets/workflow-assets/sinks/index.mdx
+++ b/docs/assets/workflow-assets/sinks/index.mdx
@@ -21,10 +21,10 @@ Sinks for writing to traditional file systems and network shares.
 | Sink | Description |
 |------|-------------|
 | [Sink File System](./asset-sink-file) | Write files to the local file system accessible by the Reactive Engine. No Connection asset required. |
-| [Sink NFS](./asset-sink-nfs) | Write files to Network File System (NFS) shares. Requires an [NFS Connection](../connections/asset-connection-nfs). |
-| [Sink SMB](./asset-sink-smb) | Write files to SMB/CIFS shares (Windows file shares). Requires an [SMB Connection](../connections/asset-connection-smb). |
-| [Sink FTP](./asset-sink-ftp) | Write files to FTP or FTPS servers. Requires an [FTP Connection](../connections/asset-connection-ftp). |
-| [Sink WebDAV](./asset-sink-webdav) | Write files to WebDAV-enabled servers. Requires a [WebDAV Connection](../connections/asset-connection-webdav). |
+| [Sink NFS](./asset-sink-nfs) | Write files to Network File System (NFS) shares. Requires an [NFS Connection](/docs/assets/workflow-assets/connections/asset-connection-nfs). |
+| [Sink SMB](./asset-sink-smb) | Write files to SMB/CIFS shares (Windows file shares). Requires an [SMB Connection](/docs/assets/workflow-assets/connections/asset-connection-smb). |
+| [Sink FTP](./asset-sink-ftp) | Write files to FTP or FTPS servers. Requires an [FTP Connection](/docs/assets/workflow-assets/connections/asset-connection-ftp). |
+| [Sink WebDAV](./asset-sink-webdav) | Write files to WebDAV-enabled servers. Requires a [WebDAV Connection](/docs/assets/workflow-assets/connections/asset-connection-webdav). |
 
 ### Cloud Storage
 
@@ -32,8 +32,8 @@ Sinks for major cloud object storage providers.
 
 | Sink | Description |
 |------|-------------|
-| [Sink S3](./asset-sink-s3) | Write objects to Amazon S3 or S3-compatible storage (GCS, IONOS, etc.). Requires an [AWS Connection](../connections/asset-connection-aws). |
-| [Sink GCS](./asset-sink-gcs) | Write objects to Google Cloud Storage buckets. Requires a [Google Cloud Connection](../connections/asset-connection-google-cloud). |
+| [Sink S3](./asset-sink-s3) | Write objects to Amazon S3 or S3-compatible storage (GCS, IONOS, etc.). Requires an [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws). |
+| [Sink GCS](./asset-sink-gcs) | Write objects to Google Cloud Storage buckets. Requires a [Google Cloud Connection](/docs/assets/workflow-assets/connections/asset-connection-google-cloud). |
 
 ### Messaging & Streaming
 
@@ -41,11 +41,11 @@ Sinks for event streaming, message queues, and event buses.
 
 | Sink | Description |
 |------|-------------|
-| [Sink Kafka](./asset-sink-kafka) | Publish messages to Apache Kafka topics. Requires a [Kafka Connection](../connections/asset-connection-kafka). |
-| [Sink Kinesis](./asset-sink-kinesis) | Write records to Amazon Kinesis Data Streams. Requires an [AWS Connection](../connections/asset-connection-aws). |
-| [Sink SQS](./asset-sink-sqs) | Send messages to Amazon Simple Queue Service queues. Requires an [AWS Connection](../connections/asset-connection-aws). |
-| [Sink SNS](./asset-sink-sns) | Publish notifications to Amazon Simple Notification Service topics. Requires an [AWS Connection](../connections/asset-connection-aws). |
-| [Sink EventBridge](./asset-sink-eventbridge) | Send events to Amazon EventBridge event bus. Requires an [AWS Connection](../connections/asset-connection-aws). |
+| [Sink Kafka](./asset-sink-kafka) | Publish messages to Apache Kafka topics. Requires a [Kafka Connection](/docs/assets/workflow-assets/connections/asset-connection-kafka). |
+| [Sink Kinesis](./asset-sink-kinesis) | Write records to Amazon Kinesis Data Streams. Requires an [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws). |
+| [Sink SQS](./asset-sink-sqs) | Send messages to Amazon Simple Queue Service queues. Requires an [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws). |
+| [Sink SNS](./asset-sink-sns) | Publish notifications to Amazon Simple Notification Service topics. Requires an [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws). |
+| [Sink EventBridge](./asset-sink-eventbridge) | Send events to Amazon EventBridge event bus. Requires an [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws). |
 
 ### Microsoft 365
 
@@ -53,8 +53,8 @@ Sinks for Microsoft cloud services.
 
 | Sink | Description |
 |------|-------------|
-| [Sink OneDrive](./asset-sink-onedrive) | Write files to Microsoft OneDrive. Requires an [MSGraph Connection](../connections/asset-connection-msgraph). |
-| [Sink SharePoint](./asset-sink-sharepoint) | Write files to Microsoft SharePoint document libraries. Requires an [MSGraph Connection](../connections/asset-connection-msgraph). |
+| [Sink OneDrive](./asset-sink-onedrive) | Write files to Microsoft OneDrive. Requires an [MSGraph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph). |
+| [Sink SharePoint](./asset-sink-sharepoint) | Write files to Microsoft SharePoint document libraries. Requires an [MSGraph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph). |
 
 ### Network & Protocol
 
@@ -63,7 +63,7 @@ Sinks for direct network protocols and abstraction layers.
 | Sink | Description |
 |------|-------------|
 | [Sink WebSocket](./asset-sink-websocket) | Send data to a WebSocket server as a client. Connection parameters configured inline — no Connection asset required. |
-| [Sink Virtual File System](./asset-sink-virtual-fs) | Write to any backend supported by a Virtual File System Connection (local, SMB, NFS, etc.) through a unified abstraction. Requires a [Virtual File System Connection](../connections/asset-connection-virtual-fs). |
+| [Sink Virtual File System](./asset-sink-virtual-fs) | Write to any backend supported by a Virtual File System Connection (local, SMB, NFS, etc.) through a unified abstraction. Requires a [Virtual File System Connection](/docs/assets/workflow-assets/connections/asset-connection-virtual-fs). |
 
 ## How to Choose a Sink
 

--- a/docs/assets/workflow-assets/sources/asset-source-email.md
+++ b/docs/assets/workflow-assets/sources/asset-source-email.md
@@ -91,19 +91,19 @@ data processed through the configured Email source will look similar to a classi
 
 * **`Input folder`** : The directory to read emails from.
   The configured input folder must be accessible to the Reactive Engine trying to access the Email source.
-  You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+  You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 
 * **`Done folder`** : The directory to which emails are moved when fully processed. Leaving it empty, the emails will not be moved.
   The configured done folder must be accessible to the Reactive Engine trying to access the Email source.
-  You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+  You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 
 * **`Error folder`** : The directory to which emails are moved in case of a problem with the email during processing. Leaving it empty, the emails will not be moved.
   The configured error folder must be accessible to the Reactive Engine trying to access the Email source.
-  You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+  You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 
 * **`Ignore folder `** : The directory to which emails are moved in case they are configured to be ignored in the `Ignore emails` section (see next). Leaving it empty, the emails will not be moved.
   The configured ignore folder must be accessible to the Reactive Engine trying to access the Email source.
-  You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+  You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 
 A final configuration could look like this:
 

--- a/docs/assets/workflow-assets/sources/asset-source-email.md
+++ b/docs/assets/workflow-assets/sources/asset-source-email.md
@@ -26,13 +26,13 @@ Defines the specific source parameters for an Email connected endpoint.
 
 | Asset type       | Link                                                            |
 |------------------|-----------------------------------------------------------------|
-| Input Processors | [Stream Input Message](../processors-input/asset-input-message) |
+| Input Processors | [Stream Input Message](/docs/assets/workflow-assets/processors-input/asset-input-message) |
 
 ### Prerequisite
 
 You need:
 
-* [Email Connection](../connections/asset-connection-email)
+* [Email Connection](/docs/assets/workflow-assets/connections/asset-connection-email)
 
 ## Configuration
 
@@ -64,11 +64,11 @@ Configure the parameters for your Email endpoint:
 
 ![Email Connection drop-down list](./.asset-source-email_images/1714733850284.png "Email Connection drop-down list")
 
-Use the drop-down list to select an [Email Connection](../connections/asset-connection-email) that should
+Use the drop-down list to select an [Email Connection](/docs/assets/workflow-assets/connections/asset-connection-email) that should
 support this Email configuration. If it does not exist, you need to create it first.
 
 :::info
-Your [Email Connection](../connections/asset-connection-email) needs to have the following configured scope:
+Your [Email Connection](/docs/assets/workflow-assets/connections/asset-connection-email) needs to have the following configured scope:
 
 * mail.readwrite
   :::

--- a/docs/assets/workflow-assets/sources/asset-source-file.md
+++ b/docs/assets/workflow-assets/sources/asset-source-file.md
@@ -59,7 +59,7 @@ None
 ### Internal
 
 * [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream)
-* [File System Sink](../sinks/asset-sink-file)
+* [File System Sink](/docs/assets/workflow-assets/sinks/asset-sink-file)
 
 ### External
 

--- a/docs/assets/workflow-assets/sources/asset-source-file.md
+++ b/docs/assets/workflow-assets/sources/asset-source-file.md
@@ -24,7 +24,7 @@ Defines the specific source parameters for a File System connected endpoint.
 
 | Asset type       | Link                                                             |
 |------------------|------------------------------------------------------------------|
-| Input Processors | [Stream Input Processor](../processors-input/asset-input-stream) |
+| Input Processors | [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream) |
 
 ### Prerequisite
 
@@ -58,7 +58,7 @@ None
 
 ### Internal
 
-* [Stream Input Processor](../processors-input/asset-input-stream)
+* [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream)
 * [File System Sink](../sinks/asset-sink-file)
 
 ### External

--- a/docs/assets/workflow-assets/sources/asset-source-ftp.md
+++ b/docs/assets/workflow-assets/sources/asset-source-ftp.md
@@ -23,13 +23,13 @@ Defines the specific bucket and folder source of a FTP connected endpoint.
 
 | Asset type       | Link                                                                       |
 |------------------|----------------------------------------------------------------------------|
-| Input Processors | [Stream Input Processor](../processors-input/asset-input-stream) |
+| Input Processors | [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream) |
 
 ### Prerequisite
 
 You need:
 
-* [FTP Connection](../connections/asset-connection-ftp)
+* [FTP Connection](/docs/assets/workflow-assets/connections/asset-connection-ftp)
 
 ## Configuration
 
@@ -63,7 +63,7 @@ If you want this restriction, then enter the names of the `Required Roles` here.
 
 ![](.asset-source-ftp_images/df31d8ca.png "FTP Connection (FTP Source)")
 
-Select the previously configured [FTP Connection](../connections/asset-connection-ftp) to use for this Source.
+Select the previously configured [FTP Connection](/docs/assets/workflow-assets/connections/asset-connection-ftp) to use for this Source.
 
 ### Folders
 
@@ -73,7 +73,7 @@ Select the previously configured [FTP Connection](../connections/asset-connectio
 
 ### Internal
 
-* [FTP Connection](../connections/asset-connection-ftp)
+* [FTP Connection](/docs/assets/workflow-assets/connections/asset-connection-ftp)
 * [FTP Sink](../sinks/asset-sink-ftp)
 
 ### External

--- a/docs/assets/workflow-assets/sources/asset-source-ftp.md
+++ b/docs/assets/workflow-assets/sources/asset-source-ftp.md
@@ -74,7 +74,7 @@ Select the previously configured [FTP Connection](/docs/assets/workflow-assets/c
 ### Internal
 
 * [FTP Connection](/docs/assets/workflow-assets/connections/asset-connection-ftp)
-* [FTP Sink](../sinks/asset-sink-ftp)
+* [FTP Sink](/docs/assets/workflow-assets/sinks/asset-sink-ftp)
 
 ### External
 

--- a/docs/assets/workflow-assets/sources/asset-source-google-cloud-storage.md
+++ b/docs/assets/workflow-assets/sources/asset-source-google-cloud-storage.md
@@ -17,19 +17,19 @@ import ThrottlingAndFailure from '../../../snippets/assets/_asset-source-throttl
 
 ## Purpose
 
-Polls one or more Google Cloud Storage (GCS) buckets for objects and makes them available to downstream processors. Authentication is handled via a [Google Cloud Connection](../connections/asset-connection-google-cloud) using OAuth 2.0. Objects can be filtered by prefix, suffix, and regular expression patterns. Housekeeping rules can be configured to automatically delete processed objects after a configurable age threshold.
+Polls one or more Google Cloud Storage (GCS) buckets for objects and makes them available to downstream processors. Authentication is handled via a [Google Cloud Connection](/docs/assets/workflow-assets/connections/asset-connection-google-cloud) using OAuth 2.0. Objects can be filtered by prefix, suffix, and regular expression patterns. Housekeeping rules can be configured to automatically delete processed objects after a configurable age threshold.
 
 ### This Asset can be used by:
 
 | Asset type       | Link                                                               |
 |------------------|--------------------------------------------------------------------|
-| Input Processors | [Stream Input Processor](../processors-input/asset-input-stream)   |
+| Input Processors | [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream)   |
 
 ### Prerequisites
 
 You need:
 
-- A [**Google Cloud Connection**](../connections/asset-connection-google-cloud) with a valid OAuth client configured
+- A [**Google Cloud Connection**](/docs/assets/workflow-assets/connections/asset-connection-google-cloud) with a valid OAuth client configured
 - A GCS bucket reachable from the Google Cloud project referenced by the connection
 
 ## Configuration
@@ -68,7 +68,7 @@ Click **"+ ADD A BUCKET"** to add a new bucket entry. Use the toolbar to reorder
 
 #### Bucket Entry Fields
 
-**Connection** — Select the [Google Cloud Connection](../connections/asset-connection-google-cloud) to use for accessing this bucket. The dropdown shows only valid Google Cloud Connection assets.
+**Connection** — Select the [Google Cloud Connection](/docs/assets/workflow-assets/connections/asset-connection-google-cloud) to use for accessing this bucket. The dropdown shows only valid Google Cloud Connection assets.
 
 ![Bucket Connection](./.Google_Cloud_Storage_Source_images/gcs-source-bucket-connection.png "Bucket Connection")
 
@@ -114,7 +114,7 @@ The **Access Coordinator** tracks which objects have been processed to prevent d
 
 ## See Also
 
-- [**Google Cloud Connection**](../connections/asset-connection-google-cloud) — OAuth configuration for GCS access
+- [**Google Cloud Connection**](/docs/assets/workflow-assets/connections/asset-connection-google-cloud) — OAuth configuration for GCS access
 - [**GCS Sink**](../sinks/asset-sink-gcs) — Write objects to Google Cloud Storage
 - [**VFS Source**](asset-source-virtual-fs.md) — Read files from a Virtual File System mount
 

--- a/docs/assets/workflow-assets/sources/asset-source-google-cloud-storage.md
+++ b/docs/assets/workflow-assets/sources/asset-source-google-cloud-storage.md
@@ -115,7 +115,7 @@ The **Access Coordinator** tracks which objects have been processed to prevent d
 ## See Also
 
 - [**Google Cloud Connection**](/docs/assets/workflow-assets/connections/asset-connection-google-cloud) — OAuth configuration for GCS access
-- [**GCS Sink**](../sinks/asset-sink-gcs) — Write objects to Google Cloud Storage
+- [**GCS Sink**](/docs/assets/workflow-assets/sinks/asset-sink-gcs) — Write objects to Google Cloud Storage
 - [**VFS Source**](asset-source-virtual-fs.md) — Read files from a Virtual File System mount
 
 ---

--- a/docs/assets/workflow-assets/sources/asset-source-http.md
+++ b/docs/assets/workflow-assets/sources/asset-source-http.md
@@ -26,7 +26,7 @@ Defines the specific source parameters for a Http connected endpoint.
 
 ### Prerequisite
 
-* [Http-Format(s)](../formats/asset-format-http)
+* [Http-Format(s)](/docs/assets/workflow-assets/formats/asset-format-http)
 
 ## Configuration
 
@@ -42,7 +42,7 @@ Defines the specific source parameters for a Http connected endpoint.
 
 ### Format dependencies
 
-Assign 1-n configured [Http-Format(s)](../formats/asset-format-http) that should be handled through the configured Http-Server.
+Assign 1-n configured [Http-Format(s)](/docs/assets/workflow-assets/formats/asset-format-http) that should be handled through the configured Http-Server.
 You can assign more than one Http-Format in order to handle multiple "Request-Response"s through the configured Http-Server Port (see next).
 
 ![Format dependencies (Http Source)](./.asset-source-http_images/1715763201303.png "Format dependencies (Http Source)")

--- a/docs/assets/workflow-assets/sources/asset-source-http.md
+++ b/docs/assets/workflow-assets/sources/asset-source-http.md
@@ -22,7 +22,7 @@ Defines the specific source parameters for a Http connected endpoint.
 
 | Asset type       | Link                                                                                           |
 |------------------|------------------------------------------------------------------------------------------------|
-| Input Processors | [Request-Response Input Processor](../processors-input/asset-input-request-response) |
+| Input Processors | [Request-Response Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-request-response) |
 
 ### Prerequisite
 
@@ -47,7 +47,7 @@ You can assign more than one Http-Format in order to handle multiple "Request-Re
 
 ![Format dependencies (Http Source)](./.asset-source-http_images/1715763201303.png "Format dependencies (Http Source)")
 
-The configuration of a [Request-Response Input Processor](../processors-input/asset-input-request-response) using this Http Source Asset 
+The configuration of a [Request-Response Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-request-response) using this Http Source Asset 
 allows the definition of the dedicated format to be processed for a specific Workflow.
  
 ### HTTP / HTTPS Server

--- a/docs/assets/workflow-assets/sources/asset-source-kafka.md
+++ b/docs/assets/workflow-assets/sources/asset-source-kafka.md
@@ -19,13 +19,13 @@ Defines the inbound connection parameters for a Kafka Source.
 
 | Asset type       | Link                                                                     |
 |------------------|--------------------------------------------------------------------------|
-| Input Processors | [Kafka Input Processor](../processors-input/asset-input-kafka) |
+| Input Processors | [Kafka Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-kafka) |
 
 ### Prerequisite
 
 You need:
 
-* [Kafka Connection](../connections/asset-connection-kafka)
+* [Kafka Connection](/docs/assets/workflow-assets/connections/asset-connection-kafka)
 
 ## Configuration
 
@@ -51,7 +51,7 @@ If you want this restriction, then enter the names of the `Required Roles` here.
 
 ![](.asset-source-kafka-images/a44e1dd8.png "Kafka Connection (Kafka Source Asset)")
 
-Select the [Kafka Connection](../connections/asset-connection-kafka) to use with this Asset.
+Select the [Kafka Connection](/docs/assets/workflow-assets/connections/asset-connection-kafka) to use with this Asset.
 If it does not exist, you need to create it first.
 
 #### Additional Kafka Properties
@@ -79,10 +79,10 @@ Click **`ADD TOPIC`** to add new topics. Enter the **`Topic`** and **`Group Id`*
 
 ### Internal
 
-* [Kafka Input Processor](../processors-input/asset-input-kafka)
+* [Kafka Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-kafka)
 * [Frame Output Processor](../processors-output/asset-output-frame)
 * [Kafka Sink](../sinks/asset-sink-kafka)
-* [Kafka Connection](../connections/asset-connection-kafka)
+* [Kafka Connection](/docs/assets/workflow-assets/connections/asset-connection-kafka)
 
 ### External
 

--- a/docs/assets/workflow-assets/sources/asset-source-kafka.md
+++ b/docs/assets/workflow-assets/sources/asset-source-kafka.md
@@ -80,8 +80,8 @@ Click **`ADD TOPIC`** to add new topics. Enter the **`Topic`** and **`Group Id`*
 ### Internal
 
 * [Kafka Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-kafka)
-* [Frame Output Processor](../processors-output/asset-output-frame)
-* [Kafka Sink](../sinks/asset-sink-kafka)
+* [Frame Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-frame)
+* [Kafka Sink](/docs/assets/workflow-assets/sinks/asset-sink-kafka)
 * [Kafka Connection](/docs/assets/workflow-assets/connections/asset-connection-kafka)
 
 ### External

--- a/docs/assets/workflow-assets/sources/asset-source-message.md
+++ b/docs/assets/workflow-assets/sources/asset-source-message.md
@@ -18,7 +18,7 @@ Define a Message Source. A Message Source defines one or more topics that can be
 
 ### Architecture
 
-The Message Source is the **consumer side** of layline.io's internal messaging system. The corresponding **producer side** is the [Message Service](../services/asset-service-message.md), which is used to publish messages to topics defined in a Message Source.
+The Message Source is the **consumer side** of layline.io's internal messaging system. The corresponding **producer side** is the [Message Service](/docs/assets/workflow-assets/services/asset-service-message.md), which is used to publish messages to topics defined in a Message Source.
 
 Together, they form a publish/subscribe system:
 
@@ -36,7 +36,7 @@ flowchart LR
     IP -->|"processes"| WF
 ```
 
-Messages published via a Message Service are routed to the configured topic. Any Input Processor (such as [Stream Input](../processors-input/asset-input-stream) or [Frame Input](../processors-input/asset-input-frame)) that references this Message Source can subscribe to and consume those messages.
+Messages published via a Message Service are routed to the configured topic. Any Input Processor (such as [Stream Input](/docs/assets/workflow-assets/processors-input/asset-input-stream) or [Frame Input](/docs/assets/workflow-assets/processors-input/asset-input-frame)) that references this Message Source can subscribe to and consume those messages.
 
 ### Use Cases
 
@@ -51,14 +51,14 @@ A Message Source is useful in scenarios such as:
 
 | Asset type | Link |
 |------------|------|
-| Input Processors | [Stream Input](../processors-input/asset-input-stream) |
-| | [Frame Input](../processors-input/asset-input-frame) |
+| Input Processors | [Stream Input](/docs/assets/workflow-assets/processors-input/asset-input-stream) |
+| | [Frame Input](/docs/assets/workflow-assets/processors-input/asset-input-frame) |
 
 ### Related Asset
 
 | Asset | Description |
 |-------|-------------|
-| [Message Service](../services/asset-service-message.md) | Publishes messages to topics defined in this Message Source |
+| [Message Service](/docs/assets/workflow-assets/services/asset-service-message.md) | Publishes messages to topics defined in this Message Source |
 
 ## Configuration
 
@@ -104,7 +104,7 @@ Click **Add Topic** to add a new topic entry.
 
 ### How It Works
 
-In a layline.io Workflow, a Message Source is assigned to an Input Processor (such as [Stream Input](../processors-input/asset-input-stream) or [Frame Input](../processors-input/asset-input-frame)). The Input Processor connects to the source and receives messages from the configured topics. The messages are then passed through the Workflow for processing.
+In a layline.io Workflow, a Message Source is assigned to an Input Processor (such as [Stream Input](/docs/assets/workflow-assets/processors-input/asset-input-stream) or [Frame Input](/docs/assets/workflow-assets/processors-input/asset-input-frame)). The Input Processor connects to the source and receives messages from the configured topics. The messages are then passed through the Workflow for processing.
 
 Topics with `Cluster` scope are visible and accessible from any Reactive Engine node in the cluster. Topics with `Node` scope are only visible to the local node, which can be useful for node-local caching or coordination.
 
@@ -112,7 +112,7 @@ The number of partitions determines how many parallel instances of a processor c
 
 ### Example: Publishing to a Topic
 
-To publish messages to a topic, use a [Message Service](../services/asset-service-message.md) from a JavaScript or Python processor. The Message Service references this Message Source and exposes functions that publish to its topics.
+To publish messages to a topic, use a [Message Service](/docs/assets/workflow-assets/services/asset-service-message.md) from a JavaScript or Python processor. The Message Service references this Message Source and exposes functions that publish to its topics.
 
 Example (JavaScript):
 
@@ -130,7 +130,7 @@ function publishOrderConfirmation(orderData) {
 }
 ```
 
-For a complete example, see [Message Service](../services/asset-service-message.md).
+For a complete example, see [Message Service](/docs/assets/workflow-assets/services/asset-service-message.md).
 
 For information on using JavaScript Processors, see [JavaScript Processor](../processors-flow/asset-flow-javascript.md).
 

--- a/docs/assets/workflow-assets/sources/asset-source-message.md
+++ b/docs/assets/workflow-assets/sources/asset-source-message.md
@@ -132,7 +132,7 @@ function publishOrderConfirmation(orderData) {
 
 For a complete example, see [Message Service](/docs/assets/workflow-assets/services/asset-service-message.md).
 
-For information on using JavaScript Processors, see [JavaScript Processor](../processors-flow/asset-flow-javascript.md).
+For information on using JavaScript Processors, see [JavaScript Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript.md).
 
 ---
 

--- a/docs/assets/workflow-assets/sources/asset-source-nfs.md
+++ b/docs/assets/workflow-assets/sources/asset-source-nfs.md
@@ -24,13 +24,13 @@ Defines the specific mount point and directory source of an NFS connected endpoi
 
 | Asset type       | Link                                                                       |
 |------------------|----------------------------------------------------------------------------|
-| Input Processors | [Stream Input Processor](../processors-input/asset-input-stream) |
+| Input Processors | [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream) |
 
 ### Prerequisite
 
 You need:
 
-* [NFS Connection](../connections/asset-connection-nfs)
+* [NFS Connection](/docs/assets/workflow-assets/connections/asset-connection-nfs)
 
 ## Configuration
 
@@ -54,7 +54,7 @@ You need:
 
 ![NFS Settings (NFS Source)](.asset-source-nfs_images/image_37.png "NFS Settings (NFS Source)")
 
-Select the previously configured [NFS Connection](../connections/asset-connection-nfs) that you want to use for this Source.
+Select the previously configured [NFS Connection](/docs/assets/workflow-assets/connections/asset-connection-nfs) that you want to use for this Source.
 
 ### Folders
 
@@ -66,9 +66,9 @@ The folder paths specified here are relative to the NFS export path configured i
 
 ### Internal
 
-* [NFS Connection](../connections/asset-connection-nfs)
+* [NFS Connection](/docs/assets/workflow-assets/connections/asset-connection-nfs)
 * [NFS Sink](../sinks/asset-sink-nfs)
-* [Stream Input Processor](../processors-input/asset-input-stream)
+* [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream)
 
 ### External
 

--- a/docs/assets/workflow-assets/sources/asset-source-nfs.md
+++ b/docs/assets/workflow-assets/sources/asset-source-nfs.md
@@ -67,7 +67,7 @@ The folder paths specified here are relative to the NFS export path configured i
 ### Internal
 
 * [NFS Connection](/docs/assets/workflow-assets/connections/asset-connection-nfs)
-* [NFS Sink](../sinks/asset-sink-nfs)
+* [NFS Sink](/docs/assets/workflow-assets/sinks/asset-sink-nfs)
 * [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream)
 
 ### External

--- a/docs/assets/workflow-assets/sources/asset-source-onedrive.md
+++ b/docs/assets/workflow-assets/sources/asset-source-onedrive.md
@@ -24,13 +24,13 @@ Defines the specific source parameters for a OneDrive connected endpoint.
 
 | Asset type       | Link                                                                       |
 |------------------|----------------------------------------------------------------------------|
-| Input Processors | [Stream Input Processor](../processors-input/asset-input-stream) |
+| Input Processors | [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream) |
 
 ### Prerequisite
 
 You need:
 
-* [MS Graph Connection](../connections/asset-connection-msgraph)
+* [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph)
 
 ## Configuration
 
@@ -62,11 +62,11 @@ Configure the parameters for your OneDrive endpoint:
 
 ![MSGraph Connection drop-down list](./.asset-source-sharepoint_images/1714663912005.png "MSGraph Connection drop-down list")
 
-Use the drop-down list to select an [MS Graph Connection](../connections/asset-connection-msgraph) that should
+Use the drop-down list to select an [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph) that should
 support this SharePoint configuration. If it does not exist, you need to create it first.
 
 :::info
-Your [MS Graph Connection](../connections/asset-connection-msgraph) needs to have the following configured scope:
+Your [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph) needs to have the following configured scope:
 * Sites.ReadWrite.All
 * Files.ReadWrite.All
 :::

--- a/docs/assets/workflow-assets/sources/asset-source-s3.md
+++ b/docs/assets/workflow-assets/sources/asset-source-s3.md
@@ -25,13 +25,13 @@ This UI helps to define the specific bucket and folder source of an S3 connected
 
 | Asset type       | Link                                                                       |
 |------------------|----------------------------------------------------------------------------|
-| Input Processors | [Stream Input Processor](../processors-input/asset-input-stream) |
+| Input Processors | [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream) |
 
 
 ## Prerequisite
 
 You need:
-* [AWS Connection](../connections/asset-connection-aws)
+* [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws)
 
 ## Configuration
 
@@ -64,7 +64,7 @@ If you want this restriction, then enter the names of the `Required Roles` here.
 
 ![](.asset-source-simages/3e8a642a.png "AWS Connection (S3 Source)")
 
-Select the previously configured [AWS Connection](../connections/asset-connection-aws) to use for this Source.
+Select the previously configured [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws) to use for this Source.
 
 ### S3 Bucket
 
@@ -97,7 +97,7 @@ This usually helps to resolve the issue.
 ## Related Topics
 
 ### Internal
-* [S3 Connection](../connections/asset-connection-aws)
+* [S3 Connection](/docs/assets/workflow-assets/connections/asset-connection-aws)
 * [S3 Sink](../sinks/asset-sink-s3)
 
 ### External

--- a/docs/assets/workflow-assets/sources/asset-source-s3.md
+++ b/docs/assets/workflow-assets/sources/asset-source-s3.md
@@ -98,7 +98,7 @@ This usually helps to resolve the issue.
 
 ### Internal
 * [S3 Connection](/docs/assets/workflow-assets/connections/asset-connection-aws)
-* [S3 Sink](../sinks/asset-sink-s3)
+* [S3 Sink](/docs/assets/workflow-assets/sinks/asset-sink-s3)
 
 ### External
 * [Cron on Wikipedia](https://en.wikipedia.org/wiki/Cron)

--- a/docs/assets/workflow-assets/sources/asset-source-service.md
+++ b/docs/assets/workflow-assets/sources/asset-source-service.md
@@ -25,7 +25,7 @@ The data is then available for further processing by other Assets in the same Wo
 It is important to understand, that the same JDBC Service Asset can also be used as an ordinary Service Asset for use in other Assets which allow to use Services Assets.
 So you could have a JDBC Servivce Asset that you use as an inpput Service for this Service Source Asset, and yet use the same JDBC Service Asset within a Scripting Asset (e.g. to read a configuration).
 
-Depending on their setup other Service Assets like [Http](../services/asset-service-http) or [SOAP](../services/asset-service-soap) might also serve the input data aspect. 
+Depending on their setup other Service Assets like [Http](/docs/assets/workflow-assets/services/asset-service-http) or [SOAP](/docs/assets/workflow-assets/services/asset-service-soap) might also serve the input data aspect. 
 Basically layline.io allows any Service Asset to be used as a Service Source. Though, you need to check whether an available service reflects a reasonable input source respectively other approaches might be more applicable (e.g.: Email Service vs. Email Source).     
 
 ![Service Source Asset](.asset-source-service_images/image_25.png "Service Source Asset")
@@ -34,7 +34,7 @@ Basically layline.io allows any Service Asset to be used as a Service Source. Th
 
 | Asset type       | Link                                                                         |
 |------------------|------------------------------------------------------------------------------|
-| Input Processors | [Service Input Processor](../processors-input/asset-input-service) |
+| Input Processors | [Service Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-service) |
 
 ### Prerequisite
 
@@ -42,12 +42,12 @@ You need:
 
 **A Service Asset, of either**
 
-* [Aerospike](../services/asset-service-aerospike)
-* [Cassandra](../services/asset-service-cassandra)
-* [Hazelcast](../services/asset-service-hazelcast)
-* [Http](../services/asset-service-http)
-* [JDBC](../services/asset-service-jdbc)
-* [SOAP](../services/asset-service-soap)
+* [Aerospike](/docs/assets/workflow-assets/services/asset-service-aerospike)
+* [Cassandra](/docs/assets/workflow-assets/services/asset-service-cassandra)
+* [Hazelcast](/docs/assets/workflow-assets/services/asset-service-hazelcast)
+* [Http](/docs/assets/workflow-assets/services/asset-service-http)
+* [JDBC](/docs/assets/workflow-assets/services/asset-service-jdbc)
+* [SOAP](/docs/assets/workflow-assets/services/asset-service-soap)
 
 (other Service Assets are available while at this stage the ones linked in here are making most sense at this stage)
 

--- a/docs/assets/workflow-assets/sources/asset-source-sharepoint.md
+++ b/docs/assets/workflow-assets/sources/asset-source-sharepoint.md
@@ -25,13 +25,13 @@ Defines the specific source parameters for a SharePoint connected endpoint.
 
 | Asset type       | Link                                                                       |
 |------------------|----------------------------------------------------------------------------|
-| Input Processors | [Stream Input Processor](../processors-input/asset-input-stream) |
+| Input Processors | [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream) |
 
 ### Prerequisite
 
 You need:
 
-* [MS Graph Connection](../connections/asset-connection-msgraph)
+* [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph)
 
 ## Configuration
 
@@ -63,11 +63,11 @@ Configure the parameters for your SharePoint endpoint:
 
 ![MSGraph Connection drop-down list](./.asset-source-sharepoint_images/1714663912005.png "MSGraph Connection drop-down list")
 
-Use the drop-down list to select an [MS Graph Connection](../connections/asset-connection-msgraph) that should
+Use the drop-down list to select an [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph) that should
 support this SharePoint configuration. If it does not exist, you need to create it first.
 
 :::info
-Your [MS Graph Connection](../connections/asset-connection-msgraph) needs to have the following configured scope:
+Your [MS Graph Connection](/docs/assets/workflow-assets/connections/asset-connection-msgraph) needs to have the following configured scope:
 * Sites.ReadWrite.All
 * Files.ReadWrite.All
 :::

--- a/docs/assets/workflow-assets/sources/asset-source-smb.md
+++ b/docs/assets/workflow-assets/sources/asset-source-smb.md
@@ -24,13 +24,13 @@ Defines the specific source parameters for a SMB connected endpoint.
 
 | Asset type       | Link                                                                       |
 |------------------|----------------------------------------------------------------------------|
-| Input Processors | [Stream Input Processor](../processors-input/asset-input-stream) |
+| Input Processors | [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream) |
 
 ### Prerequisite
 
 You need:
 
-* [SMB Connection](../connections/asset-connection-smb)
+* [SMB Connection](/docs/assets/workflow-assets/connections/asset-connection-smb)
 
 ## Configuration
 
@@ -60,7 +60,7 @@ Configure the parameters for your SMB endpoint:
 
 #### Connection
 
-Use the drop-down list to select an [SMB Connection](../connections/asset-connection-smb) that should
+Use the drop-down list to select an [SMB Connection](/docs/assets/workflow-assets/connections/asset-connection-smb) that should
 support this SMB configuration. If it does not exist, you need to create it first.
 
 #### Share

--- a/docs/assets/workflow-assets/sources/asset-source-smb.md
+++ b/docs/assets/workflow-assets/sources/asset-source-smb.md
@@ -66,7 +66,7 @@ support this SMB configuration. If it does not exist, you need to create it firs
 #### Share
 
 * **`Share`** : Configure your basic location information for your SMB endpoint. 
-You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 
 ### Folders
 

--- a/docs/assets/workflow-assets/sources/asset-source-sqs.md
+++ b/docs/assets/workflow-assets/sources/asset-source-sqs.md
@@ -62,7 +62,7 @@ Use the drop-down list to select an [AWS Connection](/docs/assets/workflow-asset
 
 Once you picked an SQS Connection above the system will try to test the connection and
 show available queues within the drop-down list under `SQS Queue`. Pick the topic you want to process messages from. Another approach 
-could be: You can use $\{...\} macros to expand variables defined in [environment variables](../resources/asset-resource-environment).
+could be: You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 
 #### Further settings
 
@@ -75,7 +75,7 @@ Amazon SQS sends an empty response only if the here configured polling wait time
 * **`Visibility timeout [sec]`**: The visibility timeout begins when Amazon SQS returns a message. During this time, the consumer has to process and delete the message. 
 You can define this timeout period in here. After the visibility timeout period the message becomes visible to other consumers again if it is not deleted. 
 If a message must be received only once, your consumer should delete it within the duration of the visibility timeout. ( see also [SQS Visibility Timeout](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)).
-Within lalyine.io you need to ensure this behavior by adding the [Input Frame Committer](../processors-flow/asset-flow-input-frame-committer) processor into your workflow since this is the instance that would finally delete the message from the queue.
+Within lalyine.io you need to ensure this behavior by adding the [Input Frame Committer](/docs/assets/workflow-assets/processors-flow/asset-flow-input-frame-committer) processor into your workflow since this is the instance that would finally delete the message from the queue.
 Please note: DELETE is only executed when message has reached the Input Frame Committer!
 
 

--- a/docs/assets/workflow-assets/sources/asset-source-sqs.md
+++ b/docs/assets/workflow-assets/sources/asset-source-sqs.md
@@ -28,13 +28,13 @@ This UI helps to define the specific bucket and folder source of an SQS connecte
 
 | Asset type       | Link                                                                     |
 |------------------|--------------------------------------------------------------------------|
-| Input Processors | [Frame Input Processor](../processors-input/asset-input-frame) |
+| Input Processors | [Frame Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-frame) |
 
 ### Prerequisite
 
 You need:
 
-* [AWS Connection](../connections/asset-connection-aws)
+* [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws)
 
 ## Configuration
 
@@ -56,7 +56,7 @@ Configure the parameters for your SQS endpoint:
 
 #### SQS Connection
 
-Use the drop-down list to select an [AWS Connection](../connections/asset-connection-aws) that should support this Asset. If it does not exist, you need to create it first.
+Use the drop-down list to select an [AWS Connection](/docs/assets/workflow-assets/connections/asset-connection-aws) that should support this Asset. If it does not exist, you need to create it first.
 
 #### SQS Queue
 

--- a/docs/assets/workflow-assets/sources/asset-source-tcp.md
+++ b/docs/assets/workflow-assets/sources/asset-source-tcp.md
@@ -22,7 +22,7 @@ TCP is a connection-oriented (stateful) protocol — unlike UDP, a TCP connectio
 
 | Asset type | Link |
 |---|---|
-| Input Processors | [Stream Input Processor](../processors-input/asset-input-stream) |
+| Input Processors | [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream) |
 | Output Processors | [Stream Output Processor](../processors-output/asset-output-stream) |
 
 ### Prerequisite

--- a/docs/assets/workflow-assets/sources/asset-source-tcp.md
+++ b/docs/assets/workflow-assets/sources/asset-source-tcp.md
@@ -23,7 +23,7 @@ TCP is a connection-oriented (stateful) protocol — unlike UDP, a TCP connectio
 | Asset type | Link |
 |---|---|
 | Input Processors | [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream) |
-| Output Processors | [Stream Output Processor](../processors-output/asset-output-stream) |
+| Output Processors | [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream) |
 
 ### Prerequisite
 

--- a/docs/assets/workflow-assets/sources/asset-source-timer.md
+++ b/docs/assets/workflow-assets/sources/asset-source-timer.md
@@ -26,7 +26,7 @@ What will be relevant is that something should happen, and the timer source make
 
 ## Used by
 
-* [Input Message](../processors-input/asset-input-message)
+* [Input Message](/docs/assets/workflow-assets/processors-input/asset-input-message)
 
 ## Configuration
 
@@ -123,7 +123,7 @@ A new timer with default values is automatically created. Let's go through the p
 
 In this mode, the Timer Source will not use its own internal timer but will rely on the timer service to trigger messages. The timer service will be used to trigger messages at specified intervals.
 
-So instead of defining timers within the Timer Source, you will define them in the [Timer Service](../services/asset-service-timer).
+So instead of defining timers within the Timer Source, you will define them in the [Timer Service](/docs/assets/workflow-assets/services/asset-service-timer).
 
 ![Using timer service (Timer Source)](.asset-source-timer_images/image_44.png "Using timer service (Timer Source)")
 
@@ -213,8 +213,8 @@ When a message is issued within a Batch or Event Stream and sent downstream in t
 ## Related Topics
 
 ### Internal
-* [Input Message](../processors-input/asset-input-message)
-* [Timer Service](../services/asset-service-timer)
+* [Input Message](/docs/assets/workflow-assets/processors-input/asset-input-message)
+* [Timer Service](/docs/assets/workflow-assets/services/asset-service-timer)
 
 ### External
 * [Cron](https://en.wikipedia.org/wiki/Cron)

--- a/docs/assets/workflow-assets/sources/asset-source-udp.md
+++ b/docs/assets/workflow-assets/sources/asset-source-udp.md
@@ -20,7 +20,7 @@ Defines the specific source parameters for a UDP connected endpoint.
 
 | Asset type       | Link                                                                     |
 |------------------|--------------------------------------------------------------------------|
-| Input Processors | [Frame Input Processor](../processors-input/asset-input-frame) |
+| Input Processors | [Frame Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-frame) |
 
 ### Prerequisite
 

--- a/docs/assets/workflow-assets/sources/asset-source-virtual-fs.md
+++ b/docs/assets/workflow-assets/sources/asset-source-virtual-fs.md
@@ -22,13 +22,13 @@ Polls a Virtual File System (VFS) for files and makes them available to downstre
 
 | Asset type       | Link                                                               |
 |------------------|--------------------------------------------------------------------|
-| Input Processors | [Stream Input Processor](../processors-input/asset-input-stream)   |
+| Input Processors | [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream)   |
 
 ### Prerequisite
 
 You need:
 
-- A [**Virtual File System Connection**](../connections/asset-connection-virtual-fs)
+- A [**Virtual File System Connection**](/docs/assets/workflow-assets/connections/asset-connection-virtual-fs)
 
 ## Configuration
 
@@ -58,7 +58,7 @@ In case you are deploying to a Cluster with Reactive Engine Nodes that have spec
 
 ![Virtual File System Settings (Virtual File System Source)](./.Virtual_File_System_Source_images/vfs-source-vfs-settings.png "Virtual File System Settings (Virtual File System Source)")
 
-**Connection** — Select the [Virtual File System Connection](../connections/asset-connection-virtual-fs) to use for reading files. If no connection exists, create one first.
+**Connection** — Select the [Virtual File System Connection](/docs/assets/workflow-assets/connections/asset-connection-virtual-fs) to use for reading files. If no connection exists, create one first.
 
 ### Folders
 

--- a/docs/assets/workflow-assets/sources/asset-source-webdav.md
+++ b/docs/assets/workflow-assets/sources/asset-source-webdav.md
@@ -24,13 +24,13 @@ Defines the specific source parameters for a WebDAV connected endpoint.
 
 | Asset type       | Link                                                                       |
 |------------------|----------------------------------------------------------------------------|
-| Input Processors | [Stream Input Processor](../processors-input/asset-input-stream) |
+| Input Processors | [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream) |
 
 ### Prerequisite
 
 You need:
 
-* [WebDAV Connection](../connections/asset-connection-webdav)
+* [WebDAV Connection](/docs/assets/workflow-assets/connections/asset-connection-webdav)
 
 ## Configuration
 
@@ -57,7 +57,7 @@ You need:
 ![Connection (WebDAV Source)](./.asset-source-webdav_images/1715691789968.png "Connection (WebDAV Source)")
 
 
-Select the previously configured [WebDAV Connection](../connections/asset-connection-webdav) to use for this Source.
+Select the previously configured [WebDAV Connection](/docs/assets/workflow-assets/connections/asset-connection-webdav) to use for this Source.
 If it does not exist, you need to create it first.
 
 ### Folders

--- a/docs/assets/workflow-assets/workflows/index.mdx
+++ b/docs/assets/workflow-assets/workflows/index.mdx
@@ -78,7 +78,7 @@ Configure notifications for Workflow lifecycle events. Each event type uses the 
 
 ## Example: IoT Sensor Processing Workflow
 
-This example builds on the [TCP Source](../sources/asset-source-tcp.md) and [Stream Input Processor](../processors-input/asset-input-stream) to create a complete sensor data ingestion pipeline.
+This example builds on the [TCP Source](/docs/assets/workflow-assets/sources/asset-source-tcp) and [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream) to create a complete sensor data ingestion pipeline.
 
 ### Goal
 
@@ -88,12 +88,12 @@ Receive temperature and humidity readings from IoT sensors over TCP, filter out 
 
 | Asset | Role in workflow |
 |-------|-----------------|
-| [Source TCP](../sources/asset-source-tcp.md) `SensorTcpSource` | Listens on `acme.sensor.host:9000` |
-| [Stream Input Processor](../processors-input/asset-input-stream) `SensorInput` | Reads the TCP stream as newline-delimited JSON |
-| [JavaScript Flow Processor](../processors-flow/asset-flow-javascript) `FilterReadings` | Filters readings by temperature range |
-| [Stream Output Processor](../processors-output/asset-output-stream) `SensorOutput` | Writes cleaned records to a file |
-| [Generic Format](../formats/asset-format-generic) `SensorFormat` | Defines the structure of a sensor reading |
-| [File Sink](../sinks/asset-sink-file) `SensorLogSink` | Output file `sensor-log.json` |
+| [Source TCP](/docs/assets/workflow-assets/sources/asset-source-tcp) `SensorTcpSource` | Listens on `acme.sensor.host:9000` |
+| [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream) `SensorInput` | Reads the TCP stream as newline-delimited JSON |
+| [JavaScript Flow Processor](/docs/assets/workflow-assets/processors-flow/asset-flow-javascript) `FilterReadings` | Filters readings by temperature range |
+| [Stream Output Processor](/docs/assets/workflow-assets/processors-output/asset-output-stream) `SensorOutput` | Writes cleaned records to a file |
+| [Generic Format](/docs/assets/workflow-assets/formats/asset-format-generic) `SensorFormat` | Defines the structure of a sensor reading |
+| [File Sink](/docs/assets/workflow-assets/sinks/asset-sink-file) `SensorLogSink` | Output file `sensor-log.json` |
 
 ### Workflow canvas
 
@@ -133,6 +133,6 @@ graph LR
 ## See Also
 
 * [Project](/docs/concept/projects-workflows/project) — Workflows are contained within Projects
-* [Stream Input Processor](../processors-input/asset-input-stream) — the required entry point of every Workflow
+* [Stream Input Processor](/docs/assets/workflow-assets/processors-input/asset-input-stream) — the required entry point of every Workflow
 * [Deployment](../../../concept/projects-workflows/deployment.md) — how Workflows are deployed to an engine
 * [Alarm Center](../../../operations/cluster/alarm-center/alarm-center) — how alarming events are routed and handled

--- a/docs/language-reference/javascript/API/classes/Message.md
+++ b/docs/language-reference/javascript/API/classes/Message.md
@@ -293,13 +293,13 @@ This method allows you to search for status entries using three different approa
 
 ##### value
 
+[`Vendor`](Vendor.md) \| [`Severity`](../enumerations/Severity.md) \| ((`status`) => `boolean`)
+
 The filter to apply:
   - If a [Vendor](Vendor.md) is provided, it returns all statuses from that vendor.
   - If a [Severity](../enumerations/Severity.md) is provided, it returns all statuses of that severity level.
   - If a function is provided, it should take a [Status](Status.md) as input and return a boolean.
     The method will return all statuses for which this function returns `true`.
-
-[`Vendor`](Vendor.md) | [`Severity`](../enumerations/Severity.md) | (`status`) => `boolean`
 
 #### Returns
 
@@ -1044,9 +1044,9 @@ message.setByte(dataDictionary.type.Detail.CSV.FIELD, 'X')
 
 ##### value
 
-A native Byte value or a value which can be implicitly converted to such.
+`string` \| `number`
 
-`string` | `number`
+A native Byte value or a value which can be implicitly converted to such.
 
 #### Returns
 
@@ -1169,9 +1169,9 @@ message.setDecimal(dataDictionary.type.Detail.CSV.FIELD, 123.45)
 
 ##### value
 
-A value which can be represented as a Decimal.
+[`BigDecimal`](../enumerations/JavaType.md#bigdecimal) \| [`BigInteger`](../enumerations/JavaType.md#biginteger) \| [`Double`](../enumerations/JavaType.md#double) \| [`Integer`](../enumerations/JavaType.md#integer) \| [`Long`](../enumerations/JavaType.md#long) \| [`Number`](../enumerations/JavaType.md#number) \| [`String`](../enumerations/JavaType.md#string)
 
-[`BigDecimal`](../enumerations/JavaType.md#bigdecimal) | [`BigInteger`](../enumerations/JavaType.md#biginteger) | [`Double`](../enumerations/JavaType.md#double) | [`Integer`](../enumerations/JavaType.md#integer) | [`Long`](../enumerations/JavaType.md#long) | [`Number`](../enumerations/JavaType.md#number) | [`String`](../enumerations/JavaType.md#string)
+A value which can be represented as a Decimal.
 
 #### Returns
 
@@ -1201,9 +1201,9 @@ message.setDouble(dataDictionary.type.Detail.CSV.FIELD, 123.45)
 
 ##### value
 
-A value which can be represented as a Double.
+`Number` \| [`BigDecimal`](../enumerations/JavaType.md#bigdecimal) \| [`BigInteger`](../enumerations/JavaType.md#biginteger) \| [`Double`](../enumerations/JavaType.md#double) \| [`Integer`](../enumerations/JavaType.md#integer) \| [`Long`](../enumerations/JavaType.md#long) \| [`String`](../enumerations/JavaType.md#string)
 
-`Number` | [`BigDecimal`](../enumerations/JavaType.md#bigdecimal) | [`BigInteger`](../enumerations/JavaType.md#biginteger) | [`Double`](../enumerations/JavaType.md#double) | [`Integer`](../enumerations/JavaType.md#integer) | [`Long`](../enumerations/JavaType.md#long) | [`String`](../enumerations/JavaType.md#string)
+A value which can be represented as a Double.
 
 #### Returns
 
@@ -1233,9 +1233,9 @@ message.setInt(dataDictionary.type.Detail.CSV.FIELD, 123)
 
 ##### value
 
-A value which can be represented as a Int.
+`Number` \| `Uint8Array` \| [`BigDecimal`](../enumerations/JavaType.md#bigdecimal) \| [`Double`](../enumerations/JavaType.md#double) \| [`Integer`](../enumerations/JavaType.md#integer) \| [`Long`](../enumerations/JavaType.md#long) \| [`String`](../enumerations/JavaType.md#string)
 
-`Number` | `Uint8Array` | [`BigDecimal`](../enumerations/JavaType.md#bigdecimal) | [`Double`](../enumerations/JavaType.md#double) | [`Integer`](../enumerations/JavaType.md#integer) | [`Long`](../enumerations/JavaType.md#long) | [`String`](../enumerations/JavaType.md#string)
+A value which can be represented as a Int.
 
 #### Returns
 
@@ -1265,9 +1265,9 @@ message.setLong(dataDictionary.type.Detail.CSV.FIELD, 12345)
 
 ##### value
 
-A value which can be represented as a Long.
+[`BigDecimal`](../enumerations/JavaType.md#bigdecimal) \| [`BigInteger`](../enumerations/JavaType.md#biginteger) \| [`Double`](../enumerations/JavaType.md#double) \| [`Integer`](../enumerations/JavaType.md#integer) \| [`Long`](../enumerations/JavaType.md#long) \| [`Number`](../enumerations/JavaType.md#number) \| [`String`](../enumerations/JavaType.md#string)
 
-[`BigDecimal`](../enumerations/JavaType.md#bigdecimal) | [`BigInteger`](../enumerations/JavaType.md#biginteger) | [`Double`](../enumerations/JavaType.md#double) | [`Integer`](../enumerations/JavaType.md#integer) | [`Long`](../enumerations/JavaType.md#long) | [`Number`](../enumerations/JavaType.md#number) | [`String`](../enumerations/JavaType.md#string)
+A value which can be represented as a Long.
 
 #### Returns
 

--- a/docs/language-reference/javascript/API/classes/Processor.md
+++ b/docs/language-reference/javascript/API/classes/Processor.md
@@ -164,9 +164,9 @@ You can view this both via the Audit Trail in the UI and output in the process t
 
 ##### param
 
-Information you want to log. Can be either a string message or a Status object.
+`string` \| [`Status`](Status.md)
 
-`string` | [`Status`](Status.md)
+Information you want to log. Can be either a string message or a Status object.
 
 #### Returns
 
@@ -196,9 +196,9 @@ You can view this both via the Audit Trail in the UI and output in the process t
 
 ##### param
 
-Information you want to log. Can be either a string message or a Status object.
+`string` \| [`Status`](Status.md)
 
-`string` | [`Status`](Status.md)
+Information you want to log. Can be either a string message or a Status object.
 
 #### Returns
 
@@ -228,9 +228,9 @@ You can view this both via the Audit Trail in the UI and output in the process t
 
 ##### param
 
-Information you want to log. Can be either a string message or a Status object.
+`string` \| [`Status`](Status.md)
 
-`string` | [`Status`](Status.md)
+Information you want to log. Can be either a string message or a Status object.
 
 #### Returns
 
@@ -260,9 +260,9 @@ You can view this both via the Audit Trail in the UI and output in the process t
 
 ##### param
 
-Information you want to log. Can be either a string message or a Status object.
+`string` \| [`Status`](Status.md)
 
-`string` | [`Status`](Status.md)
+Information you want to log. Can be either a string message or a Status object.
 
 #### Returns
 

--- a/docs/language-reference/javascript/API/interfaces/DataDictionaryTypes.md
+++ b/docs/language-reference/javascript/API/interfaces/DataDictionaryTypes.md
@@ -27,7 +27,7 @@ if (message.is(dataDictionary.type.SomeNamespace.SomeMessageType)) {
 
 ## Indexable
 
-\[`key`: `string`\]: `any`
+> \[`key`: `string`\]: `any`
 
 Allows for dynamic properties based on the specific configuration.
 These can be namespaces, sequences, or other types of declarations.

--- a/docs/operations/cluster/security-storage.md
+++ b/docs/operations/cluster/security-storage.md
@@ -224,4 +224,4 @@ The log view uses the same shared log component as other Operations pages. Event
 - [**Settings Secret Storage**](/docs/settings/secret-storage) — Settings-level vault for managing cryptographic material that can be referenced across deployments
 - [**Cluster Overview**](/docs/operations/cluster/cluster-overview) — Introduction to the cluster operations panel
 - [**Access Coordinator**](/docs/operations/cluster/access-coordinator) — Manages resource and source coordination across cluster nodes
-- [**OAuthClient Resource**](/docs/assets/resources/resource-oauth-client) — Configures OAuth clients for use within workflow assets
+- [**OAuthClient Resource**](/docs/assets/workflow-assets/resources/resource-oauth-client) — Configures OAuth clients for use within workflow assets


### PR DESCRIPTION
## Summary

Fixes ~200 broken links (404 errors) in the documentation that were caused by incorrect relative path resolution.

## Problem

Docusaurus was incorrectly resolving relative links like `../connections/` from within `sinks/` files, creating wrong URLs like:
- `/docs/assets/workflow-assets/sinks/connections/asset-connection-nfs/` (404)

Instead of the correct:
- `/docs/assets/workflow-assets/connections/asset-connection-nfs/` (200)

## Changes

Changed relative cross-category links to absolute paths in 69 files:

- **From sinks/**: `../connections/` → `/docs/assets/workflow-assets/connections/`
- **From sinks/**: `../processors-output/` → `/docs/assets/workflow-assets/processors-output/`
- **From connections/**: `../sinks/` → `/docs/assets/workflow-assets/sinks/`
- **From connections/**: `../sources/` → `/docs/assets/workflow-assets/sources/`
- **From sources/**: `../connections/`, `../services/`, `../processors-input/` → absolute paths
- **From formats/**: `../processors-flow/` → absolute paths
- **From services/**: `../connections/`, `../processors-flow/` → absolute paths
- And similar fixes for other cross-category links

## Verification

- `npm run build` completes successfully
- Confirmed broken links like `sinks/connections/` are no longer present in build output

## Remaining broken links

~90 links remain 404ing due to missing content pages (not fixable by link correction):
- Language reference pages (JavaScript/Python API docs)
- Concept pages that haven't been written yet
- Operations pages that don't exist