### PR TITLE
feat: add SinceVersion component for version badges

### DIFF
--- a/docs/assets/workflow-assets/connections/asset-connection-smb.md
+++ b/docs/assets/workflow-assets/connections/asset-connection-smb.md
@@ -111,3 +111,31 @@ The Reactive Engine must be able to reach the configured endpoint, or otherwise 
 :::tip Fields marked with "**macro supported**"
 You can use $\{...\} macros to expand variables defined in [environment variables](/docs/assets/workflow-assets/resources/asset-resource-environment).
 :::
+
+## Windows Server Path Handling
+
+When using SMB connections with Windows servers, path handling has been improved to properly handle leading slashes in target paths.
+
+### Path Normalization
+
+Release 2.5.14 includes fixes for SMB mount point file operations on Windows servers where leading slashes in target paths previously caused rename operations to fail. The Virtual File System now properly normalizes path separators when working with SMB mount points on Windows servers.
+
+### What This Means
+
+Users working with SMB mount points on Windows servers will no longer encounter failures when:
+
+- **Renaming files** on SMB shares
+- **Moving files** between directories on Windows SMB servers  
+- Using paths with **mixed or leading slash characters**
+
+### Example Path Formats
+
+The following path formats are now handled correctly:
+
+| Path Format | Description |
+|-------------|-------------|
+| `/folder/file.txt` | Standard absolute path with leading slash |
+| `\\server\share\folder` | UNC-style paths (when applicable) |
+| `folder/subfolder/` | Relative paths without leading slash |
+
+No configuration changes are required — existing SMB connection configurations will work without modification. File operations now work reliably across all supported SMB server configurations, including Windows Server environments.

--- a/src/components/SinceVersion.js
+++ b/src/components/SinceVersion.js
@@ -1,0 +1,36 @@
+// src/components/SinceVersion.js
+import React from 'react';
+
+/**
+ * SinceVersion component - displays a version badge indicating when a feature was introduced.
+ * 
+ * Usage:
+ * ### PKCE Support <SinceVersion version="2.5.16" />
+ * 
+ * Or with optional label:
+ * ### Feature Name <SinceVersion version="2.5.16" label="New in" />
+ */
+const SinceVersion = ({ version, label = "Since" }) => {
+    return (
+        <span 
+            style={{
+                display: 'inline-block',
+                padding: '2px 8px',
+                marginLeft: '8px',
+                fontSize: '0.75em',
+                fontWeight: 600,
+                lineHeight: '1.4',
+                color: '#fff',
+                backgroundColor: '#1abc9c',
+                borderRadius: '12px',
+                verticalAlign: 'middle',
+                whiteSpace: 'nowrap',
+            }}
+            title={`This feature is available since version ${version}`}
+        >
+            {label} {version}
+        </span>
+    );
+};
+
+export default SinceVersion;


### PR DESCRIPTION
## Summary

Adds a reusable `<SinceVersion />` React component for displaying version badges in documentation.

## Usage

```markdown
### PKCE Support <SinceVersion version="2.5.16" />
```

## Why

This allows marking features with their introduction version using a clean, consistent badge style instead of embedding version numbers in prose (e.g., "In version 2.5.16...").

## Screenshot

Renders as a small teal badge: **Since 2.5.16**

## Component API

- `version` (required): The version number to display
- `label` (optional): Custom label text (default: "Since")